### PR TITLE
✨ Support non-legacy keys via base64 encoding

### DIFF
--- a/memcache/experiment/async_meta_client.py
+++ b/memcache/experiment/async_meta_client.py
@@ -68,7 +68,8 @@ class AsyncMetaClient:
         self, key: Union[str, bytes]
     ) -> AsyncIterator[AsyncConnection]:
         if isinstance(key, bytes):
-            key = key.decode("utf-8")
+            # latin-1 maps every byte 1:1 so binary keys never raise here.
+            key = key.decode("latin-1")
         pool = self._connections.get_node(key)
         async with pool.get() as connection:
             yield connection
@@ -176,7 +177,7 @@ class AsyncMetaClient:
         """Retrieve multiple keys; missing keys are omitted from the result."""
         result: Dict[str, GetResult[Any]] = {}
         for key in keys:
-            key_str = key if isinstance(key, str) else key.decode("utf-8")
+            key_str = key if isinstance(key, str) else key.decode("latin-1")
             gr = await self.get(key)
             if gr is not None:
                 result[key_str] = gr

--- a/memcache/experiment/meta_client.py
+++ b/memcache/experiment/meta_client.py
@@ -93,7 +93,8 @@ class MetaClient:
     @contextmanager
     def _get_connection(self, key: Union[str, bytes]) -> Iterator[Connection]:
         if isinstance(key, bytes):
-            key = key.decode("utf-8")
+            # latin-1 maps every byte 1:1 so binary keys never raise here.
+            key = key.decode("latin-1")
         pool = self._connections.get_node(key)
         with pool.get() as connection:
             yield connection
@@ -201,7 +202,7 @@ class MetaClient:
         """Retrieve multiple keys; missing keys are omitted from the result."""
         result: Dict[str, GetResult[Any]] = {}
         for key in keys:
-            key_str = key if isinstance(key, str) else key.decode("utf-8")
+            key_str = key if isinstance(key, str) else key.decode("latin-1")
             gr = self.get(key)
             if gr is not None:
                 result[key_str] = gr

--- a/memcache/meta_command.py
+++ b/memcache/meta_command.py
@@ -1,7 +1,40 @@
+import base64
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 from .errors import MemcacheError
+
+# memcached limits the key token *on the wire* to 250 bytes and the legacy
+# text key may not contain whitespace or control characters. Keys that violate
+# the latter are sent base64-encoded with the meta ``b`` flag; since the server
+# checks the length before decoding, the base64 form (not the raw key) is what
+# must fit in 250 bytes, which caps a binary key at ~186 raw bytes.
+MAX_KEY_LENGTH = 250
+
+
+def _is_legacy_safe(key: bytes) -> bool:
+    """Whether ``key`` can be sent verbatim (no whitespace/control chars)."""
+    for byte in key:
+        if byte <= 0x20 or byte == 0x7F:  # control chars, space and DEL
+            return False
+    return True
+
+
+def encode_key(key: bytes) -> Tuple[bytes, bool]:
+    """Return ``(wire_key, needs_base64_flag)`` for a raw key.
+
+    Raises :class:`MemcacheError` if the wire key exceeds memcached's limit.
+    """
+    if _is_legacy_safe(key):
+        wire_key, needs_base64 = key, False
+    else:
+        wire_key, needs_base64 = base64.b64encode(key), True
+    if len(wire_key) > MAX_KEY_LENGTH:
+        raise MemcacheError(
+            f"key too long: {len(wire_key)} bytes on the wire "
+            f"exceeds maximum {MAX_KEY_LENGTH}"
+        )
+    return wire_key, needs_base64
 
 
 @dataclass(init=False)
@@ -29,11 +62,15 @@ class MetaCommand:
         self.value = value
 
     def dump_header(self) -> bytes:
+        wire_key, needs_base64 = encode_key(self.key)
+        flags = self.flags
+        if needs_base64 and b"b" not in flags:
+            flags = flags + [b"b"]
         if self.datalen is None:
-            header = b" ".join([self.cm, self.key] + self.flags + [b"\r\n"])
+            header = b" ".join([self.cm, wire_key] + flags + [b"\r\n"])
         else:
             datalen = str(self.datalen).encode("utf-8")
-            header = b" ".join([self.cm, self.key, datalen] + self.flags + [b"\r\n"])
+            header = b" ".join([self.cm, wire_key, datalen] + flags + [b"\r\n"])
         return header
 
 

--- a/tests/test_async_meta_client.py
+++ b/tests/test_async_meta_client.py
@@ -436,3 +436,17 @@ async def test_execute_meta_command(client: AsyncMetaClient) -> None:
     result2 = await client.execute_meta_command(cmd2)
     assert result2.rc == b"VA"
     assert result2.value == b"raw"
+
+
+# ------------------------------------------------------------------ #
+# Non-legacy keys: base64 encoding on the wire (b flag)              #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_set_get_non_legacy_key(client: AsyncMetaClient) -> None:
+    # End-to-end: the server accepts our base64 + `b` wire format and routing.
+    await client.set(b"crlf\r\ninjection", "payload")
+    r = await client.get(b"crlf\r\ninjection")
+    assert r is not None
+    assert r.value == "payload"

--- a/tests/test_meta_client.py
+++ b/tests/test_meta_client.py
@@ -1,10 +1,11 @@
+import base64
 import time
 
 import pytest
 
 from memcache.experiment import GetResult, MetaClient
 from memcache import MemcacheError
-from memcache.meta_command import MetaCommand, MetaResult
+from memcache.meta_command import MetaCommand, MetaResult, encode_key
 
 
 @pytest.fixture()
@@ -421,3 +422,39 @@ def test_execute_meta_command(client: MetaClient) -> None:
     result2 = client.execute_meta_command(cmd2)
     assert result2.rc == b"VA"
     assert result2.value == b"raw"
+
+
+# ------------------------------------------------------------------ #
+# Non-legacy keys: base64 encoding on the wire (b flag)              #
+# ------------------------------------------------------------------ #
+
+
+def test_encode_key() -> None:
+    # Legacy-safe keys are sent verbatim; keys with whitespace/control/binary
+    # bytes are base64-encoded; oversized keys are rejected before sending.
+    assert encode_key(b"plain_key") == (b"plain_key", False)
+    assert encode_key(b"a b") == (base64.b64encode(b"a b"), True)
+    # The 250-byte limit applies to the wire token, so a legacy key may be up
+    # to 250 bytes while a binary key is capped by its (larger) base64 form.
+    with pytest.raises(MemcacheError):
+        encode_key(b"x" * 251)
+    assert encode_key(b"\x00" * 186)[1] is True  # base64 -> 248 bytes, ok
+    with pytest.raises(MemcacheError):
+        encode_key(b"\x00" * 187)  # base64 -> 252 bytes, too long
+
+
+def test_meta_command_encodes_non_legacy_key_on_wire() -> None:
+    cmd = MetaCommand(cm=b"mg", key=b"crlf\r\ninjection", flags=[b"v"])
+    assert cmd.key == b"crlf\r\ninjection"  # raw key kept as-is
+    header = cmd.dump_header()
+    assert base64.b64encode(b"crlf\r\ninjection") in header
+    assert b" b " in header  # base64 flag appended
+    assert b"\r\n" not in header[:-2]  # raw CRLF did not corrupt the frame
+
+
+def test_set_get_non_legacy_key(client: MetaClient) -> None:
+    # End-to-end: the server accepts our base64 + `b` wire format and routing.
+    client.set(b"crlf\r\ninjection", "payload")
+    r = client.get(b"crlf\r\ninjection")
+    assert r is not None
+    assert r.value == "payload"


### PR DESCRIPTION
Keys with whitespace, control chars or non-ASCII bytes broke the wire frame and crashed the hash-ring router.

Now such keys are base64-encoded with the meta `b` flag at serialization time, while `MetaCommand.key` keeps the original key for routing. Keys over 250 bytes are rejected; routing decodes with latin-1 so binary keys never raise.