### PR TITLE
Fix memcached error response parsing

### DIFF
--- a/memcache/meta_command.py
+++ b/memcache/meta_command.py
@@ -86,13 +86,13 @@ class MetaResult:
         parts = line.split()
 
         rc = parts[0]
-        if rc == b"CLIENT_ERROR":
+        if rc in (b"CLIENT_ERROR", b"SERVER_ERROR"):
             # Old ascii protocol error.
-            raise MemcacheError(
-                line.lstrip(b"CLIENT_ERROR ")
-                .rstrip()
-                .decode("utf-8")
-            )
+            prefix = rc + b" "
+            # Use ``line.removeprefix(prefix)`` when dropping Python 3.8 support.
+            if line.startswith(prefix):
+                line = line[len(prefix) :]
+            raise MemcacheError(line.rstrip().decode("utf-8"))
 
         flags = []
         datalen = None

--- a/tests/test_meta_client.py
+++ b/tests/test_meta_client.py
@@ -44,6 +44,16 @@ def test_load_header_en() -> None:
     assert result.flags == []
 
 
+def test_load_header_client_error_preserves_message_prefix() -> None:
+    with pytest.raises(MemcacheError, match="^Invalid arguments$"):
+        MetaResult.load_header(b"CLIENT_ERROR Invalid arguments\r\n")
+
+
+def test_load_header_server_error() -> None:
+    with pytest.raises(MemcacheError, match="^Temporary failure$"):
+        MetaResult.load_header(b"SERVER_ERROR Temporary failure\r\n")
+
+
 # ------------------------------------------------------------------ #
 # get / set                                                          #
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
Fix parsing of old ASCII memcached error responses. `CLIENT_ERROR` messages now remove the exact prefix with `removeprefix()` instead of using `lstrip()`, so message text is preserved. `SERVER_ERROR` responses now use the same error handling path.