### PR TITLE
Refactor experimental meta client

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,45 +61,33 @@ Async usage mirrors the sync API with `AsyncMemcache` and `await`.
 > ]
 > ```
 
-`MetaClient` exposes the full power of memcached's
-[meta protocol](https://github.com/memcached/memcached/blob/master/doc/protocol.txt),
-including flags unavailable through the basic API.
+`MetaClient` is an intent-oriented API for memcached's meta protocol. Common methods expose operations such as conditional reads, leases and conditional writes without exposing wire flags. Every result has an explicit status.
 
 ```python
-from memcache.experiment import MetaClient
+from memcache.experiment import Get, GetStatus, Meta, MetaClient, Set
 
-client = MetaClient(("localhost", 11211))
+with MetaClient(("localhost", 11211)) as client:
+    client.set("key", {"message": "value"}, ttl=60)
 
-# get returns a GetResult with rich metadata
-result = client.get(
-    "key",
-    with_cas=True,
-    with_ttl=True,
-    with_hit_before=True,
-)
-if result is not None:
-    print(result.value)
-    print(result.cas_token)
-    print(result.ttl)
-    print(result.hit_before)
+    result = client.get("key", meta=Meta.CAS | Meta.TTL | Meta.SIZE)
+    if result.status is GetStatus.HIT:
+        print(result.value, result.item.cas, result.item.ttl)
 
-# Atomic get-and-touch (update TTL in the same round-trip)
-value = client.gat("key", expire=120)
+    # Batch operations use a quiet pipeline and preserve input order.
+    results = client.batch([Get("key"), Get("missing"), Set("other", b"x")])
 
-# Store only if key does not exist
-client.add("key", "value", expire=60)
+    # C only transfers the value if it changed, in one round trip.
+    latest = client.get("key", unless_cas=result.item.cas)
+    if latest.status is GetStatus.UNCHANGED:
+        use_local_copy()
 
-# Store only if key already exists
-client.replace("key", "new_value")
-
-# Increment with auto-create if missing
-client.incr("counter", delta=1, initial=0, initial_ttl=3600)
-
-# Flush with a delay
-client.flush_all(delay=30)
+    # Atomic cache-miss lease. Only one caller receives GRANTED.
+    lease = client.get_with_lease("report", lease_ttl=30)
+    if lease.lease_state.name == "GRANTED":
+        lease.fulfill(build_report(), ttl=300)
 ```
 
-`AsyncMetaClient` is the async counterpart with the same interface.
+`AsyncMetaClient` has the same concepts and call shape; its methods and lease `fulfill()` are awaited. Protocol experts can use `client.raw.execute(...)` as a framing-safe escape hatch. See `docs/meta-client-design.md` for the complete state and failure model.
 
 ## About the Project
 

--- a/memcache/async_connection.py
+++ b/memcache/async_connection.py
@@ -1,6 +1,6 @@
 import asyncio
 from contextlib import asynccontextmanager
-from typing import AsyncIterator, Callable, Optional, Tuple
+from typing import AsyncIterator, Callable, List, Optional, Tuple
 
 import anyio
 from anyio.streams.buffered import BufferedByteReceiveStream
@@ -27,6 +27,12 @@ class AsyncConnection:
         self.reader = BufferedByteReceiveStream(self.writer)
         await self._auth()
         self._connected = True
+
+    async def close(self) -> None:
+        self._connected = False
+        writer = getattr(self, "writer", None)
+        if writer is not None:
+            await writer.aclose()
 
     async def _auth(self) -> None:
         if self._username is None or self._password is None:
@@ -57,9 +63,9 @@ class AsyncConnection:
     async def execute_meta_command(self, command: MetaCommand) -> MetaResult:
         try:
             return await self._execute_meta_command(command)
-        except (IndexError, ConnectionResetError, BrokenPipeError):
+        except BaseException:
             self._connected = False
-            return await self._execute_meta_command(command)
+            raise
 
     async def _execute_meta_command(self, command: MetaCommand) -> MetaResult:
         if not self._connected:
@@ -69,6 +75,37 @@ class AsyncConnection:
         if command.value:
             await self.writer.send(command.value + b"\r\n")
         return await self._receive_meta_result()
+
+    async def execute_pipeline(self, commands: List[MetaCommand]) -> List[MetaResult]:
+        """Write a quiet pipeline and read through its ``mn`` barrier.
+
+        ``PipelineError.written`` is conservative: an operation is counted as
+        written as soon as its first send starts, since a failed send may have
+        transferred an arbitrary prefix to the kernel.
+        """
+        written = 0
+        responses: List[MetaResult] = []
+        try:
+            if not self._connected:
+                await self._connect()
+            for command in commands:
+                written += 1
+                await self.writer.send(command.dump())
+            await self.writer.send(b"mn\r\n")
+            while True:
+                line = await self.reader.receive_until(b"\r\n", max_bytes=1024)
+                if line == b"MN":
+                    return responses
+                result = MetaResult.load_header(line)
+                if result.rc == b"VA":
+                    if result.datalen is None:
+                        raise MemcacheError("invalid response: missing datalen")
+                    result.value = await self.reader.receive_exactly(result.datalen)
+                    await self.reader.receive_exactly(2)
+                responses.append(result)
+        except BaseException as exc:
+            self._connected = False
+            raise PipelineError(written, responses, exc)
 
     async def _receive_meta_result(self) -> MetaResult:
         header_line = await self.reader.receive_until(b"\r\n", max_bytes=1024)
@@ -81,6 +118,19 @@ class AsyncConnection:
             await self.reader.receive_exactly(2)  # read the "\r\n"
 
         return result
+
+
+class PipelineError(Exception):
+    def __init__(
+        self,
+        written: int,
+        responses: List[MetaResult],
+        cause: BaseException,
+    ) -> None:
+        super().__init__(str(cause))
+        self.written = written
+        self.responses = responses
+        self.cause = cause
 
 
 class AsyncPool:
@@ -101,18 +151,37 @@ class AsyncPool:
     async def get(self) -> AsyncIterator[AsyncConnection]:
         try:
             connection = self._connections.get_nowait()
-            yield connection
-            await self._connections.put(connection)
         except asyncio.QueueEmpty:
             if self._max_size and self._size >= self._max_size:
                 connection = await asyncio.wait_for(
                     self._connections.get(), timeout=self._timeout
                 )
-                yield connection
-                await self._connections.put(connection)
             else:
                 async with self._lock:
                     self._size += 1
-                connection = self._create_connection()
-                yield connection
-                await self._connections.put(connection)
+                try:
+                    connection = self._create_connection()
+                except BaseException:
+                    async with self._lock:
+                        self._size -= 1
+                    raise
+        try:
+            yield connection
+        except BaseException:
+            try:
+                await connection.close()
+            finally:
+                async with self._lock:
+                    self._size -= 1
+            raise
+        else:
+            await self._connections.put(connection)
+
+    async def close(self) -> None:
+        while True:
+            try:
+                connection = self._connections.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            await connection.close()
+        self._size = 0

--- a/memcache/async_memcache.py
+++ b/memcache/async_memcache.py
@@ -4,7 +4,9 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Union
 from .async_connection import AsyncConnection, AsyncPool  # noqa: F401 re-export
 from .connection import Addr
 from .errors import MemcacheError
+from .experiment import IfCas, Meta
 from .experiment.async_meta_client import AsyncMetaClient
+from .experiment.result import GetStatus, MutationStatus
 from .meta_command import MetaCommand, MetaResult
 from .serialize import dump, load, DumpFunc, LoadFunc
 
@@ -75,11 +77,11 @@ class AsyncMemcache:
     async def set(
         self, key: Union[bytes, str], value: Any, *, expire: Optional[int] = None
     ) -> None:
-        await self._meta.set(key, value, expire=expire)
+        await self._meta.set(key, value, ttl=expire)
 
     async def get(self, key: Union[bytes, str]) -> Optional[Any]:
         r = await self._meta.get(key)
-        return r.value if r is not None else None
+        return r.value if r.status is GetStatus.HIT else None
 
     async def gets(self, key: Union[bytes, str]) -> Optional[Tuple[Any, int]]:
         """
@@ -88,8 +90,8 @@ class AsyncMemcache:
         :param key: The key to retrieve
         :return: A tuple of (value, cas_token) or None if key doesn't exist
         """
-        r = await self._meta.get(key, with_cas=True)
-        if r is None:
+        r = await self._meta.get(key, meta=Meta.CAS)
+        if r.status is not GetStatus.HIT:
             return None
         if r.cas_token is None:
             raise MemcacheError("CAS token not found in response")
@@ -112,38 +114,61 @@ class AsyncMemcache:
         :param expire: Optional expiration time in seconds
         :raises MemcacheError: If the CAS token doesn't match or other error occurs
         """
-        ok = await self._meta.cas(key, value, cas_token, expire=expire)
-        if not ok:
+        result = await self._meta.set(
+            key,
+            value,
+            ttl=expire,
+            condition=IfCas(cas_token),
+        )
+        if result.status is not MutationStatus.STORED:
             raise MemcacheError("CAS operation failed: token mismatch or other error")
 
     async def delete(self, key: Union[bytes, str]) -> bool:
-        return await self._meta.delete(key)
+        return (await self._meta.delete(key)).status is MutationStatus.STORED
 
     async def touch(self, key: Union[bytes, str], expire: int) -> bool:
-        return await self._meta.touch(key, expire)
+        return (await self._meta.touch(key, expire)).status is MutationStatus.STORED
 
     async def add(
         self, key: Union[bytes, str], value: Any, *, expire: Optional[int] = None
     ) -> bool:
-        return await self._meta.add(key, value, expire=expire)
+        return (
+            await self._meta.add(key, value, ttl=expire)
+        ).status is MutationStatus.STORED
 
     async def replace(
         self, key: Union[bytes, str], value: Any, *, expire: Optional[int] = None
     ) -> bool:
-        return await self._meta.replace(key, value, expire=expire)
+        return (
+            await self._meta.replace(key, value, ttl=expire)
+        ).status is MutationStatus.STORED
 
     async def append(self, key: Union[bytes, str], value: Any) -> bool:
-        return await self._meta.append(key, value)
+        return (
+            await self._meta.append_bytes(key, value)
+        ).status is MutationStatus.STORED
 
     async def prepend(self, key: Union[bytes, str], value: Any) -> bool:
-        return await self._meta.prepend(key, value)
+        return (
+            await self._meta.prepend_bytes(key, value)
+        ).status is MutationStatus.STORED
 
     async def get_many(self, keys: List[Union[bytes, str]]) -> Dict[str, Any]:
         results = await self._meta.get_many(keys)
-        return {k: v.value for k, v in results.items()}
+        return {
+            r.key if isinstance(r.key, str) else r.key.decode("latin-1"): r.value
+            for r in results
+            if r.status is GetStatus.HIT
+        }
 
     async def incr(self, key: Union[bytes, str], value: int = 1) -> int:
-        return await self._meta.incr(key, value)
+        result = await self._meta.increment(key, value)
+        if result.status is not MutationStatus.STORED or result.value is None:
+            raise MemcacheError("key not found")
+        return result.value
 
     async def decr(self, key: Union[bytes, str], value: int = 1) -> int:
-        return await self._meta.decr(key, value)
+        result = await self._meta.decrement(key, value)
+        if result.status is not MutationStatus.STORED or result.value is None:
+            raise MemcacheError("key not found")
+        return result.value

--- a/memcache/connection.py
+++ b/memcache/connection.py
@@ -62,12 +62,9 @@ class Connection:
             raise MemcacheError(response.rstrip(NEWLINE))
 
     def execute_meta_command(self, command: MetaCommand) -> MetaResult:
-        try:
-            return self._execute_meta_command(command)
-        except (IndexError, ConnectionResetError, BrokenPipeError):
-            # This happens when connection is closed by memcached.
-            self._connect()
-            return self._execute_meta_command(command)
+        # Never reconnect and replay here. Once a write has started, a lost
+        # response makes the outcome ambiguous (especially for ms/ma).
+        return self._execute_meta_command(command)
 
     def _execute_meta_command(self, command: MetaCommand) -> MetaResult:
         self.stream.write(command.dump_header())
@@ -106,16 +103,26 @@ class Pool:
     def get(self) -> Iterator[Connection]:
         try:
             connection = self._connections.get_nowait()
-            yield connection
-            self._connections.put(connection)
         except queue.Empty:
             if self._max_size and self._size >= self._max_size:
                 connection = self._connections.get(timeout=self._timeout)
-                yield connection
-                self._connections.put(connection)
             else:
                 with self._lock:
                     self._size += 1
-                connection = self._create_connection()
-                yield connection
-                self._connections.put(connection)
+                try:
+                    connection = self._create_connection()
+                except BaseException:
+                    with self._lock:
+                        self._size -= 1
+                    raise
+        try:
+            yield connection
+        except BaseException:
+            try:
+                connection.close()
+            finally:
+                with self._lock:
+                    self._size -= 1
+            raise
+        else:
+            self._connections.put(connection)

--- a/memcache/errors.py
+++ b/memcache/errors.py
@@ -1,6 +1,21 @@
+from typing import Any, Optional
+
+
 class MemcacheError(Exception):
-    ...
+    pass
 
 
 class SerializeError(MemcacheError):
-    ...
+    pass
+
+
+class AmbiguousWriteError(MemcacheError):
+    """A request was sent but its terminal response was not received."""
+
+    def __init__(self, result: Optional[Any] = None) -> None:
+        super().__init__("operation outcome is ambiguous")
+        self.result = result
+
+
+class ProtocolError(MemcacheError):
+    """The server returned a malformed or unsupported protocol response."""

--- a/memcache/experiment/__init__.py
+++ b/memcache/experiment/__init__.py
@@ -1,5 +1,44 @@
+from ..errors import AmbiguousWriteError, ProtocolError
 from .async_meta_client import AsyncMetaClient
 from .meta_client import MetaClient
-from .result import GetResult
+from .operation import ABSENT, PRESENT, Delete, Get, IfCas, Increment, Set
+from .result import (
+    ArithmeticResult,
+    BatchResult,
+    GetResult,
+    GetStatus,
+    ItemMeta,
+    LeaseResult,
+    LeaseState,
+    Meta,
+    MutationResult,
+    MutationStatus,
+    ResultValueError,
+    ValueState,
+)
 
-__all__ = ["MetaClient", "AsyncMetaClient", "GetResult"]
+__all__ = [
+    "ABSENT",
+    "PRESENT",
+    "AmbiguousWriteError",
+    "ArithmeticResult",
+    "AsyncMetaClient",
+    "BatchResult",
+    "Delete",
+    "Get",
+    "GetResult",
+    "GetStatus",
+    "IfCas",
+    "Increment",
+    "ItemMeta",
+    "LeaseResult",
+    "LeaseState",
+    "Meta",
+    "MetaClient",
+    "MutationResult",
+    "MutationStatus",
+    "ProtocolError",
+    "ResultValueError",
+    "Set",
+    "ValueState",
+]

--- a/memcache/experiment/async_meta_client.py
+++ b/memcache/experiment/async_meta_client.py
@@ -1,23 +1,263 @@
-from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Dict, List, Optional, Union
+from __future__ import annotations
 
+from dataclasses import dataclass
+from contextlib import asynccontextmanager
+from typing import (
+    Any,
+    AsyncIterator,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
+
+import anyio
 import hashring
 
-from ..async_connection import AsyncConnection, AsyncPool
+from ..async_connection import AsyncConnection, AsyncPool, PipelineError
 from ..connection import Addr
-from ..errors import MemcacheError
+from ..errors import AmbiguousWriteError, MemcacheError, ProtocolError
 from ..meta_command import MetaCommand, MetaResult
-from ..serialize import dump, load, DumpFunc, LoadFunc
-from .meta_client import _parse_flags
-from .result import GetResult
+from ..serialize import DumpFunc, LoadFunc, dump, load
+from .operation import (
+    ABSENT,
+    PRESENT,
+    Delete,
+    Get,
+    IfCas,
+    Increment,
+    Operation,
+    Set,
+)
+from .result import (
+    ArithmeticResult,
+    BatchResult,
+    GetResult,
+    GetStatus,
+    ItemMeta,
+    Key,
+    LeaseResult,
+    LeaseState,
+    Meta,
+    MutationResult,
+    MutationStatus,
+    Result,
+    ValueState,
+)
+
+
+def _key_bytes(key: Key) -> bytes:
+    if isinstance(key, str):
+        return key.encode("utf-8")
+    if isinstance(key, bytes):
+        return key
+    raise TypeError("key must be str or bytes")
+
+
+def _positive(name: str, value: Optional[int], *, allow_zero: bool = True) -> None:
+    if value is None:
+        return
+    minimum = 0 if allow_zero else 1
+    if not isinstance(value, int) or value < minimum:
+        raise ValueError("%s must be an integer >= %d" % (name, minimum))
+
+
+def _response_flags(flags: Iterable[bytes]) -> Dict[str, Any]:
+    parsed: Dict[str, Any] = {}
+    for flag in flags:
+        if not flag:
+            continue
+        code = chr(flag[0])
+        token = flag[1:]
+        if code in ("f", "c", "t", "l", "s"):
+            names = {
+                "f": "client_flags",
+                "c": "cas",
+                "t": "ttl",
+                "l": "last_access",
+                "s": "size",
+            }
+            parsed[names[code]] = int(token)
+        elif code == "h":
+            parsed["hit_before"] = token != b"0"
+        elif code == "O":
+            parsed["opaque"] = token
+        elif code == "W":
+            parsed["won"] = True
+        elif code == "Z":
+            parsed["busy"] = True
+        elif code == "X":
+            parsed["stale"] = True
+    return parsed
+
+
+class _Server:
+    def __init__(
+        self,
+        addr: Addr,
+        username: Optional[str],
+        password: Optional[str],
+    ) -> None:
+        self.addr = addr
+        self._username = username
+        self._password = password
+        self._connection: Optional[AsyncConnection] = None
+        self._lock = anyio.Lock()
+
+    def __repr__(self) -> str:
+        return "%s:%d" % self.addr
+
+    async def pipeline(
+        self, commands: List[MetaCommand], timeout: Optional[float]
+    ) -> List[MetaResult]:
+        async with self._lock:
+            if self._connection is None:
+                self._connection = AsyncConnection(
+                    self.addr, username=self._username, password=self._password
+                )
+            try:
+                if timeout is None:
+                    return await self._connection.execute_pipeline(commands)
+                with anyio.fail_after(timeout):
+                    return await self._connection.execute_pipeline(commands)
+            except BaseException:
+                connection, self._connection = self._connection, None
+                if connection is not None:
+                    try:
+                        await connection.close()
+                    except BaseException:
+                        pass
+                raise
+
+    async def execute(
+        self, command: MetaCommand, timeout: Optional[float]
+    ) -> MetaResult:
+        async with self._lock:
+            if self._connection is None:
+                self._connection = AsyncConnection(
+                    self.addr, username=self._username, password=self._password
+                )
+            try:
+                if timeout is None:
+                    return await self._connection.execute_meta_command(command)
+                with anyio.fail_after(timeout):
+                    return await self._connection.execute_meta_command(command)
+            except BaseException:
+                connection, self._connection = self._connection, None
+                if connection is not None:
+                    try:
+                        await connection.close()
+                    except BaseException:
+                        pass
+                raise
+
+    async def flush(self, delay: int) -> None:
+        async with self._lock:
+            if self._connection is None:
+                self._connection = AsyncConnection(
+                    self.addr, username=self._username, password=self._password
+                )
+            try:
+                await self._connection.flush_all(delay)
+            except BaseException:
+                connection, self._connection = self._connection, None
+                if connection is not None:
+                    try:
+                        await connection.close()
+                    except BaseException:
+                        pass
+                raise
+
+    async def close(self) -> None:
+        async with self._lock:
+            connection, self._connection = self._connection, None
+            if connection is not None:
+                await connection.close()
+
+
+@dataclass
+class _Prepared:
+    index: int
+    operation: Operation
+    command: MetaCommand
+    side_effect: bool
+
+
+class AsyncRawClient:
+    def __init__(self, client: "AsyncMetaClient") -> None:
+        self._client = client
+
+    async def execute(
+        self,
+        *,
+        command: Union[str, bytes],
+        key: Key,
+        flags: Sequence[bytes] = (),
+        value: Optional[bytes] = None,
+        timeout: Optional[float] = None,
+    ) -> MetaResult:
+        cm = command.encode("ascii") if isinstance(command, str) else command
+        if len(cm) != 2:
+            raise ValueError("meta command must be exactly two bytes")
+        if value is not None and cm != b"ms":
+            raise ValueError("only a raw ms command accepts a value payload")
+        meta = MetaCommand(
+            cm=cm,
+            key=_key_bytes(key),
+            datalen=len(value) if value is not None else None,
+            flags=list(flags),
+            value=value,
+        )
+        return await self._client.execute_meta_command(meta, timeout=timeout)
+
+    async def batch(
+        self,
+        commands: Sequence[MetaCommand],
+        *,
+        timeout: Optional[float] = None,
+    ) -> List[MetaResult]:
+        # Raw batch does not infer quiet outcomes; require one response per
+        # command so output can retain input order across server shards.
+        grouped: Dict[_Server, List[Tuple[int, MetaCommand]]] = {}
+        for index, command in enumerate(commands):
+            if b"q" in command.flags:
+                raise ValueError("raw batch does not accept quiet commands")
+            server = self._client._server_for(command.key)
+            grouped.setdefault(server, []).append((index, command))
+        output: List[Optional[MetaResult]] = [None] * len(commands)
+        async with anyio.create_task_group() as tasks:
+            for server, group in grouped.items():
+                tasks.start_soon(
+                    self._run_group,
+                    server,
+                    group,
+                    output,
+                    self._client._timeout(timeout),
+                )
+        if any(result is None for result in output):
+            raise ProtocolError("raw batch left an operation unresolved")
+        return cast(List[MetaResult], output)
+
+    @staticmethod
+    async def _run_group(
+        server: _Server,
+        group: List[Tuple[int, MetaCommand]],
+        output: List[Optional[MetaResult]],
+        timeout: Optional[float],
+    ) -> None:
+        responses = await server.pipeline([command for _, command in group], timeout)
+        if len(responses) != len(group):
+            raise ProtocolError("raw batch received an unexpected response count")
+        for (index, _), response in zip(group, responses):
+            output[index] = response
 
 
 class AsyncMetaClient:
-    """
-    Async memcache client with full meta protocol capability.
-
-    Mirror of MetaClient using anyio-based AsyncConnection/AsyncPool.
-    """
+    """Intent-oriented meta protocol client with a batch-first executor."""
 
     def __init__(
         self,
@@ -25,467 +265,661 @@ class AsyncMetaClient:
         *,
         pool_size: Optional[int] = 23,
         pool_timeout: Optional[int] = 1,
+        timeout: Optional[float] = 1.0,
         load_func: LoadFunc = load,
         dump_func: DumpFunc = dump,
         username: Optional[str] = None,
         password: Optional[str] = None,
-    ):
+    ) -> None:
         self._load = load_func
         self._dump = dump_func
-
-        addr = addr or ("localhost", 11211)
-        if isinstance(addr, list):
-            addrs: List[Addr] = addr
-            nodes: List[AsyncPool] = []
-            for a in addrs:
-                def _make(a: Addr = a) -> AsyncConnection:
-                    return AsyncConnection(
-                        a,
-                        username=username,
-                        password=password,
-                    )
-                nodes.append(
-                    AsyncPool(_make, max_size=pool_size, timeout=pool_timeout)
-                )
-            self._connections = hashring.HashRing(nodes)
-        elif isinstance(addr, tuple):
-            a_single: Addr = addr
-
-            def _make_single() -> AsyncConnection:
-                return AsyncConnection(
-                    a_single,
-                    username=username,
-                    password=password,
-                )
-            self._connections = hashring.HashRing(
-                [AsyncPool(_make_single, max_size=pool_size, timeout=pool_timeout)]
-            )
+        self.default_timeout = timeout
+        addresses: List[Addr]
+        if addr is None:
+            addresses = [("localhost", 11211)]
+        elif isinstance(addr, tuple) and len(addr) == 2:
+            addresses = [addr]
+        elif isinstance(addr, list) and addr:
+            addresses = addr
         else:
-            raise TypeError("invalid type for addr")
+            raise TypeError("addr must be a server tuple or a non-empty list")
+        self._servers = [
+            _Server(server, username=username, password=password)
+            for server in addresses
+        ]
+        self._ring = hashring.HashRing(self._servers)
+        compat_pools = []
+        for server in addresses:
+
+            def make(server: Addr = server) -> AsyncConnection:
+                return AsyncConnection(server, username=username, password=password)
+
+            compat_pools.append(
+                AsyncPool(make, max_size=pool_size, timeout=pool_timeout)
+            )
+        self._compat_ring = hashring.HashRing(compat_pools)
+        self.raw = AsyncRawClient(self)
+        self._closed = False
+
+    async def __aenter__(self) -> "AsyncMetaClient":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()
+
+    def _timeout(self, timeout: Optional[float]) -> Optional[float]:
+        return self.default_timeout if timeout is None else timeout
+
+    def _server_for(self, key: Key) -> _Server:
+        routing_key = key if isinstance(key, str) else key.decode("latin-1")
+        return cast(_Server, self._ring.get_node(routing_key))
 
     @asynccontextmanager
-    async def _get_connection(
-        self, key: Union[str, bytes]
-    ) -> AsyncIterator[AsyncConnection]:
-        if isinstance(key, bytes):
-            # latin-1 maps every byte 1:1 so binary keys never raise here.
-            key = key.decode("latin-1")
-        pool = self._connections.get_node(key)
+    async def _get_connection(self, key: Key) -> AsyncIterator[AsyncConnection]:
+        """Backward-compatible private pool hook used by AsyncMemcache."""
+        routing_key = key if isinstance(key, str) else key.decode("latin-1")
+        pool = self._compat_ring.get_node(routing_key)
         async with pool.get() as connection:
             yield connection
 
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for server in self._servers:
+            await server.close()
+        for pool in self._compat_ring.nodes:
+            await pool.close()
+
+    async def execute_meta_command(
+        self, command: MetaCommand, *, timeout: Optional[float] = None
+    ) -> MetaResult:
+        if self._closed:
+            raise RuntimeError("client is closed")
+        return await self._server_for(command.key).execute(
+            command, self._timeout(timeout)
+        )
+
+    def _prepare(self, index: int, operation: Operation) -> _Prepared:
+        key = _key_bytes(operation.key)
+        if isinstance(operation, Get):
+            return self._prepare_get(index, operation, key)
+        if isinstance(operation, Set):
+            return self._prepare_set(index, operation, key)
+        if isinstance(operation, Delete):
+            return self._prepare_delete(index, operation, key)
+        if isinstance(operation, Increment):
+            return self._prepare_increment(index, operation, key)
+        raise TypeError("unsupported batch operation")
+
+    def _prepare_get(self, index: int, operation: Get, key: bytes) -> _Prepared:
+        _positive("touch", operation.touch)
+        _positive("lease_ttl", operation.lease_ttl, allow_zero=False)
+        _positive("refresh_before", operation.refresh_before, allow_zero=False)
+        if operation.refresh_before is not None and operation.lease_ttl is None:
+            raise ValueError("refresh_before requires lease_ttl")
+        if operation.unless_cas is not None and not operation.value:
+            raise ValueError("unless_cas requires a value read")
+        _positive("unless_cas", operation.unless_cas)
+        flags = [b"f"]
+        if operation.value:
+            flags.append(b"v")
+        requested_meta = operation.meta
+        if operation.lease_ttl is not None or operation.unless_cas is not None:
+            requested_meta |= Meta.CAS
+        mapping = (
+            (Meta.CAS, b"c"),
+            (Meta.TTL, b"t"),
+            (Meta.SIZE, b"s"),
+            (Meta.LAST_ACCESS, b"l"),
+            (Meta.HIT_BEFORE, b"h"),
+        )
+        flags.extend(wire for bit, wire in mapping if requested_meta & bit)
+        optional_flags = (
+            (operation.touch, b"T"),
+            (operation.unless_cas, b"C"),
+            (operation.lease_ttl, b"N"),
+            (operation.refresh_before, b"R"),
+        )
+        for value, prefix in optional_flags:
+            if value is not None:
+                flags.append(prefix + str(value).encode("ascii"))
+        if operation.no_lru_bump:
+            flags.append(b"u")
+        command = MetaCommand(b"mg", key, flags=flags)
+        side_effect = any(
+            value is not None
+            for value in (
+                operation.touch,
+                operation.lease_ttl,
+                operation.refresh_before,
+            )
+        )
+        return _Prepared(index, operation, command, side_effect)
+
+    def _prepare_set(self, index: int, operation: Set, key: bytes) -> _Prepared:
+        _positive("ttl", operation.ttl)
+        _positive("version", operation.version)
+        raw, client_flags = self._dump(key, operation.value)
+        flags = [b"F%d" % client_flags]
+        if operation.ttl is not None:
+            flags.append(b"T%d" % operation.ttl)
+        if operation.version is not None:
+            flags.append(b"E%d" % operation.version)
+        if operation.return_cas:
+            flags.append(b"c")
+        flags.extend(self._condition_flags(operation))
+        flags.extend(self._store_mode_flags(operation))
+        if operation.vivify_ttl is not None:
+            if operation.mode not in ("append", "prepend"):
+                raise ValueError("vivify_ttl is only valid for byte concatenation")
+            _positive("vivify_ttl", operation.vivify_ttl, allow_zero=False)
+            flags.append(b"N%d" % operation.vivify_ttl)
+        command = MetaCommand(b"ms", key, len(raw), flags, raw)
+        return _Prepared(index, operation, command, True)
+
     @staticmethod
-    def _to_bytes(key: Union[str, bytes]) -> bytes:
-        if isinstance(key, str):
-            return key.encode()
-        return key
+    def _condition_flags(operation: Set) -> List[bytes]:
+        condition = operation.condition
+        if condition is ABSENT:
+            return [b"ME"]
+        if condition is PRESENT:
+            return [b"MR"]
+        if isinstance(condition, IfCas):
+            return [b"C%d" % condition.token]
+        if condition is not None:
+            raise TypeError("invalid store condition")
+        return []
 
-    async def execute_meta_command(self, command: MetaCommand) -> MetaResult:
-        async with self._get_connection(command.key) as connection:
-            return await connection.execute_meta_command(command)
+    @staticmethod
+    def _store_mode_flags(operation: Set) -> List[bytes]:
+        modes = {"set": None, "append": b"MA", "prepend": b"MP"}
+        if operation.mode not in modes:
+            raise ValueError("invalid store mode")
+        mode_flag = modes[operation.mode]
+        return [mode_flag] if mode_flag is not None else []
 
-    # ------------------------------------------------------------------ #
-    # Meta Get (mg)                                                      #
-    # ------------------------------------------------------------------ #
+    def _prepare_delete(self, index: int, operation: Delete, key: bytes) -> _Prepared:
+        _positive("stale_for", operation.stale_for)
+        if operation.stale_for is not None and not operation.invalidate:
+            raise ValueError("stale_for is only valid for invalidate")
+        flags = []
+        if operation.condition is not None:
+            flags.append(b"C%d" % operation.condition.token)
+        if operation.invalidate:
+            flags.append(b"I")
+            if operation.stale_for is not None:
+                flags.append(b"T%d" % operation.stale_for)
+        return _Prepared(index, operation, MetaCommand(b"md", key, flags=flags), True)
+
+    def _prepare_increment(
+        self, index: int, operation: Increment, key: bytes
+    ) -> _Prepared:
+        _positive("delta", operation.delta)
+        _positive("initial", operation.initial)
+        _positive("initial_ttl", operation.initial_ttl, allow_zero=False)
+        _positive("ttl", operation.ttl)
+        _positive("version", operation.version)
+        if operation.initial is not None and operation.initial_ttl is None:
+            raise ValueError("initial requires initial_ttl")
+        if operation.initial_ttl is not None and operation.initial is None:
+            raise ValueError("initial_ttl requires initial")
+        flags = [b"D%d" % operation.delta, b"v"]
+        if operation.decrement:
+            flags.append(b"MD")
+        if operation.initial is not None:
+            assert operation.initial_ttl is not None
+            flags.extend([b"J%d" % operation.initial, b"N%d" % operation.initial_ttl])
+        if operation.ttl is not None:
+            flags.append(b"T%d" % operation.ttl)
+        if operation.condition is not None:
+            flags.append(b"C%d" % operation.condition.token)
+        if operation.version is not None:
+            flags.append(b"E%d" % operation.version)
+        if operation.return_cas:
+            flags.append(b"c")
+        return _Prepared(index, operation, MetaCommand(b"ma", key, flags=flags), True)
+
+    def _failure(
+        self, prepared: _Prepared, ambiguous: bool, error: BaseException
+    ) -> Result:
+        mutation_status = (
+            MutationStatus.AMBIGUOUS if ambiguous else MutationStatus.FAILED
+        )
+        operation = prepared.operation
+        if isinstance(operation, Get):
+            status = GetStatus.AMBIGUOUS if ambiguous else GetStatus.FAILED
+            return GetResult(key=operation.key, status=status, error=error)
+        if isinstance(operation, Increment):
+            return ArithmeticResult(operation.key, mutation_status, error=error)
+        return MutationResult(operation.key, mutation_status, error=error)
+
+    def _parse(self, prepared: _Prepared, response: Optional[MetaResult]) -> Result:
+        operation = prepared.operation
+        if response is None:
+            if isinstance(operation, Get):
+                return GetResult(key=operation.key, status=GetStatus.MISS)
+            if isinstance(operation, Increment):
+                return ArithmeticResult(
+                    operation.key,
+                    MutationStatus.FAILED,
+                    error=ProtocolError("arithmetic response was suppressed"),
+                )
+            return MutationResult(operation.key, MutationStatus.STORED)
+        parsed = _response_flags(response.flags)
+        if isinstance(operation, Get):
+            return self._parse_get(operation, response, parsed)
+        if isinstance(operation, Increment):
+            arithmetic_status = self._mutation_status(operation, response.rc)
+            value = (
+                int(response.value) if response.rc == b"VA" and response.value else None
+            )
+            return ArithmeticResult(
+                operation.key,
+                arithmetic_status,
+                value=value,
+                item=ItemMeta(cas=parsed.get("cas"), ttl=parsed.get("ttl")),
+            )
+        return MutationResult(
+            operation.key,
+            self._mutation_status(operation, response.rc),
+            cas=parsed.get("cas"),
+        )
+
+    def _parse_get(
+        self, operation: Get, response: MetaResult, parsed: Dict[str, Any]
+    ) -> GetResult[Any]:
+        if response.rc == b"EN":
+            return GetResult(key=operation.key, status=GetStatus.MISS)
+        if response.rc not in (b"VA", b"HD"):
+            return GetResult(
+                key=operation.key,
+                status=GetStatus.FAILED,
+                error=ProtocolError("unexpected get response %r" % response.rc),
+            )
+        item = ItemMeta(
+            cas=parsed.get("cas"),
+            ttl=parsed.get("ttl"),
+            size=parsed.get("size"),
+            last_access=parsed.get("last_access"),
+            hit_before=parsed.get("hit_before"),
+        )
+        lease_state = (
+            LeaseState.GRANTED
+            if parsed.get("won")
+            else LeaseState.BUSY if parsed.get("busy") else LeaseState.NONE
+        )
+        stale = bool(parsed.get("stale"))
+        placeholder = (
+            not stale and response.datalen == 0 and lease_state is not LeaseState.NONE
+        )
+        value_state = (
+            ValueState.STALE
+            if stale
+            else ValueState.MISSING if placeholder else ValueState.FRESH
+        )
+        has_value = False
+        value: Any = None
+        if placeholder:
+            status = (
+                GetStatus.MISS if operation.lease_ttl is not None else GetStatus.PENDING
+            )
+        elif response.rc == b"HD" and operation.unless_cas is not None:
+            status = GetStatus.UNCHANGED
+        else:
+            status = GetStatus.HIT
+            has_value = response.rc == b"VA" and response.value is not None
+            if has_value:
+                value = self._load(
+                    _key_bytes(operation.key),
+                    response.value or b"",
+                    parsed.get("client_flags", 0),
+                )
+        kwargs: Dict[str, Any] = dict(
+            key=operation.key,
+            status=status,
+            item=item,
+            value_state=value_state,
+            lease_state=lease_state,
+        )
+        if has_value:
+            kwargs["value"] = value
+        if operation.lease_ttl is None:
+            return GetResult(**kwargs)
+        cas = item.cas
+
+        async def fulfill(value: Any, **options: Any) -> MutationResult:
+            if cas is None:
+                raise ProtocolError("lease response did not include CAS")
+            return await self.set(
+                operation.key,
+                value,
+                condition=IfCas(cas),
+                **options,
+            )
+
+        return LeaseResult(fulfill=fulfill, **kwargs)
+
+    @staticmethod
+    def _mutation_status(operation: Operation, rc: bytes) -> MutationStatus:
+        if rc in (b"HD", b"VA"):
+            return MutationStatus.STORED
+        if rc == b"EX":
+            return MutationStatus.CAS_MISMATCH
+        if rc == b"NF":
+            return MutationStatus.NOT_FOUND
+        if rc == b"NS":
+            if isinstance(operation, Set) and operation.condition is ABSENT:
+                return MutationStatus.ALREADY_EXISTS
+            return MutationStatus.NOT_FOUND
+        return MutationStatus.FAILED
+
+    @staticmethod
+    def _pipeline_command(item: _Prepared) -> MetaCommand:
+        flags = item.command.flags + [b"O%d" % item.index]
+        # q suppresses the entire success line, including requested result
+        # data. Arithmetic values and returned store CAS tokens need that line.
+        needs_success_response = isinstance(item.operation, Increment) or (
+            isinstance(item.operation, Set) and item.operation.return_cas
+        )
+        if not needs_success_response:
+            flags.append(b"q")
+        return MetaCommand(
+            item.command.cm,
+            item.command.key,
+            item.command.datalen,
+            flags,
+            item.command.value,
+        )
+
+    @staticmethod
+    def _index_responses(
+        responses: Sequence[MetaResult],
+    ) -> Tuple[Dict[int, MetaResult], Optional[BaseException]]:
+        by_index: Dict[int, MetaResult] = {}
+        failure: Optional[BaseException] = None
+        for response in responses:
+            opaque = _response_flags(response.flags).get("opaque")
+            if opaque is None:
+                failure = ProtocolError("pipeline response omitted opaque token")
+                continue
+            try:
+                by_index[int(opaque)] = response
+            except ValueError:
+                failure = ProtocolError("invalid opaque token")
+        return by_index, failure
+
+    def _record_parsed(
+        self,
+        output: List[Optional[Result]],
+        item: _Prepared,
+        response: Optional[MetaResult],
+    ) -> None:
+        try:
+            output[item.index] = self._parse(item, response)
+        except BaseException as exc:
+            output[item.index] = self._failure(item, False, exc)
+
+    async def _run_group(
+        self,
+        server: _Server,
+        prepared: List[_Prepared],
+        output: List[Optional[Result]],
+        timeout: Optional[float],
+    ) -> None:
+        commands = [self._pipeline_command(item) for item in prepared]
+        responses: List[MetaResult] = []
+        written = 0
+        failure: Optional[BaseException] = None
+        barrier = False
+        try:
+            responses = await server.pipeline(commands, timeout)
+            written = len(prepared)
+            barrier = True
+        except PipelineError as exc:
+            responses = exc.responses
+            written = exc.written
+            failure = exc.cause
+        except BaseException as exc:
+            failure = exc
+        by_index, index_failure = self._index_responses(responses)
+        if index_failure is not None:
+            failure = index_failure
+        for position, item in enumerate(prepared):
+            candidate = by_index.get(item.index)
+            if candidate is not None:
+                self._record_parsed(output, item, candidate)
+            elif barrier:
+                self._record_parsed(output, item, None)
+            else:
+                error = failure or MemcacheError("pipeline did not reach barrier")
+                output[item.index] = self._failure(
+                    item,
+                    ambiguous=position < written and item.side_effect,
+                    error=error,
+                )
+
+    async def batch(
+        self,
+        operations: Sequence[Operation],
+        *,
+        timeout: Optional[float] = None,
+    ) -> BatchResult:
+        if self._closed:
+            raise RuntimeError("client is closed")
+        prepared = [self._prepare(index, op) for index, op in enumerate(operations)]
+        grouped: Dict[_Server, List[_Prepared]] = {}
+        for item in prepared:
+            grouped.setdefault(self._server_for(item.operation.key), []).append(item)
+        output: List[Optional[Result]] = [None] * len(prepared)
+        async with anyio.create_task_group() as tasks:
+            for server, group in grouped.items():
+                tasks.start_soon(
+                    self._run_group,
+                    server,
+                    group,
+                    output,
+                    self._timeout(timeout),
+                )
+        if any(item is None for item in output):
+            raise AssertionError("batch executor left an operation unresolved")
+        return BatchResult(output)  # type: ignore[arg-type]
+
+    async def _one(self, operation: Operation, timeout: Optional[float]) -> Result:
+        result = cast(Result, (await self.batch([operation], timeout=timeout))[0])
+        status = result.status
+        if status in (GetStatus.AMBIGUOUS, MutationStatus.AMBIGUOUS):
+            raise AmbiguousWriteError(result)
+        return result
 
     async def get(
         self,
-        key: Union[str, bytes],
+        key: Key,
         *,
-        with_cas: bool = False,
-        with_ttl: bool = False,
-        with_last_access: bool = False,
-        with_size: bool = False,
-        with_hit_before: bool = False,
-        update_ttl: Optional[int] = None,
+        meta: Meta = Meta.NONE,
+        touch: Optional[int] = None,
         no_lru_bump: bool = False,
-        vivify_on_miss_ttl: Optional[int] = None,
-        recache_ttl_threshold: Optional[int] = None,
-        check_cas: Optional[int] = None,
-    ) -> Optional[GetResult[Any]]:
-        key_bytes = self._to_bytes(key)
-        flags: List[bytes] = [b"v", b"f"]
-        if with_cas:
-            flags.append(b"c")
-        if with_ttl:
-            flags.append(b"t")
-        if with_last_access:
-            flags.append(b"l")
-        if with_size:
-            flags.append(b"s")
-        if with_hit_before:
-            flags.append(b"h")
-        if update_ttl is not None:
-            flags.append(b"T%d" % update_ttl)
-        if no_lru_bump:
-            flags.append(b"u")
-        if vivify_on_miss_ttl is not None:
-            flags.append(b"N%d" % vivify_on_miss_ttl)
-        if recache_ttl_threshold is not None:
-            flags.append(b"R%d" % recache_ttl_threshold)
-        if check_cas is not None:
-            flags.append(b"C%d" % check_cas)
-
-        command = MetaCommand(cm=b"mg", key=key_bytes, flags=flags)
-        async with self._get_connection(key_bytes) as connection:
-            result = await connection.execute_meta_command(command)
-
-        if result.rc == b"EN":
-            return None
-
-        parsed = _parse_flags(result.flags)
-
-        gr: GetResult[Any] = GetResult()
-        gr.is_stale = parsed.get("is_stale", False)
-        gr.won_recache = parsed.get("won_recache", False)
-        gr.already_won = parsed.get("already_won", False)
-        if with_cas:
-            gr.cas_token = parsed.get("cas_token")
-        if with_ttl:
-            gr.ttl = parsed.get("ttl")
-        if with_last_access:
-            gr.last_access = parsed.get("last_access")
-        if with_size:
-            gr.size = parsed.get("size")
-        if with_hit_before:
-            gr.hit_before = parsed.get("hit_before")
-        if "key" in parsed:
-            gr.key = parsed["key"]
-
-        if result.value is not None and len(result.value) > 0:
-            client_flags = parsed.get("client_flags", 0)
-            gr.value = self._load(key_bytes, result.value, client_flags)
-
-        return gr
-
-    async def touch(self, key: Union[str, bytes], expire: int) -> bool:
-        """Update the TTL of a key without returning its value."""
-        key_bytes = self._to_bytes(key)
-        command = MetaCommand(
-            cm=b"mg",
-            key=key_bytes,
-            flags=[b"T%d" % expire],
+        unless_cas: Optional[int] = None,
+        timeout: Optional[float] = None,
+    ) -> GetResult[Any]:
+        return await self._one(  # type: ignore[return-value]
+            Get(key, meta, touch, no_lru_bump, unless_cas), timeout
         )
-        async with self._get_connection(key_bytes) as connection:
-            result = await connection.execute_meta_command(command)
-        return result.rc != b"EN"
+
+    async def inspect(
+        self,
+        key: Key,
+        *,
+        meta: Meta = Meta.CAS | Meta.TTL | Meta.SIZE,
+        no_lru_bump: bool = True,
+        timeout: Optional[float] = None,
+    ) -> GetResult[Any]:
+        return await self._one(  # type: ignore[return-value]
+            Get(key, meta=meta, no_lru_bump=no_lru_bump, value=False), timeout
+        )
+
+    async def get_with_lease(
+        self,
+        key: Key,
+        *,
+        lease_ttl: int,
+        refresh_before: Optional[int] = None,
+        meta: Meta = Meta.NONE,
+        timeout: Optional[float] = None,
+    ) -> LeaseResult[Any]:
+        return await self._one(  # type: ignore[return-value]
+            Get(
+                key,
+                meta=meta,
+                lease_ttl=lease_ttl,
+                refresh_before=refresh_before,
+            ),
+            timeout,
+        )
 
     async def get_many(
         self,
-        keys: List[Union[str, bytes]],
-    ) -> Dict[str, GetResult[Any]]:
-        """Retrieve multiple keys; missing keys are omitted from the result."""
-        result: Dict[str, GetResult[Any]] = {}
-        for key in keys:
-            key_str = key if isinstance(key, str) else key.decode("latin-1")
-            gr = await self.get(key)
-            if gr is not None:
-                result[key_str] = gr
-        return result
-
-    # ------------------------------------------------------------------ #
-    # Meta Set (ms)                                                      #
-    # ------------------------------------------------------------------ #
+        keys: Sequence[Key],
+        *,
+        meta: Meta = Meta.NONE,
+        timeout: Optional[float] = None,
+    ) -> BatchResult:
+        return await self.batch([Get(key, meta=meta) for key in keys], timeout=timeout)
 
     async def set(
         self,
-        key: Union[str, bytes],
+        key: Key,
         value: Any,
         *,
-        expire: Optional[int] = None,
-    ) -> None:
-        key_bytes = self._to_bytes(key)
-        raw_value, client_flags = self._dump(key_bytes, value)
-        flags: List[bytes] = [b"F%d" % client_flags]
-        if expire is not None:
-            flags.append(b"T%d" % expire)
-
-        command = MetaCommand(
-            cm=b"ms",
-            key=key_bytes,
-            datalen=len(raw_value),
-            flags=flags,
-            value=raw_value,
+        ttl: Optional[int] = None,
+        condition: Any = None,
+        version: Optional[int] = None,
+        return_cas: bool = False,
+        timeout: Optional[float] = None,
+    ) -> MutationResult:
+        return await self._one(  # type: ignore[return-value]
+            Set(key, value, ttl, condition, version, return_cas), timeout
         )
-        async with self._get_connection(key_bytes) as connection:
-            result = await connection.execute_meta_command(command)
 
-        if result.rc != b"HD":
-            raise MemcacheError(f"set failed: {result.rc.decode()}")
+    async def add(self, key: Key, value: Any, **options: Any) -> MutationResult:
+        options["condition"] = ABSENT
+        return await self.set(key, value, **options)
 
-    async def add(
-        self,
-        key: Union[str, bytes],
-        value: Any,
-        *,
-        expire: Optional[int] = None,
-    ) -> bool:
-        """Store only if key does not already exist. Returns True on success."""
-        key_bytes = self._to_bytes(key)
-        raw_value, client_flags = self._dump(key_bytes, value)
-        flags: List[bytes] = [b"ME", b"F%d" % client_flags]
-        if expire is not None:
-            flags.append(b"T%d" % expire)
-
-        command = MetaCommand(
-            cm=b"ms",
-            key=key_bytes,
-            datalen=len(raw_value),
-            flags=flags,
-            value=raw_value,
-        )
-        async with self._get_connection(key_bytes) as connection:
-            result = await connection.execute_meta_command(command)
-
-        if result.rc == b"HD":
-            return True
-        if result.rc == b"NS":
-            return False
-        raise MemcacheError(f"add failed: {result.rc.decode()}")
-
-    async def replace(
-        self,
-        key: Union[str, bytes],
-        value: Any,
-        *,
-        expire: Optional[int] = None,
-    ) -> bool:
-        """Store only if key already exists. Returns True on success."""
-        key_bytes = self._to_bytes(key)
-        raw_value, client_flags = self._dump(key_bytes, value)
-        flags: List[bytes] = [b"MR", b"F%d" % client_flags]
-        if expire is not None:
-            flags.append(b"T%d" % expire)
-
-        command = MetaCommand(
-            cm=b"ms",
-            key=key_bytes,
-            datalen=len(raw_value),
-            flags=flags,
-            value=raw_value,
-        )
-        async with self._get_connection(key_bytes) as connection:
-            result = await connection.execute_meta_command(command)
-
-        if result.rc == b"HD":
-            return True
-        if result.rc == b"NS":
-            return False
-        raise MemcacheError(f"replace failed: {result.rc.decode()}")
-
-    async def append(
-        self,
-        key: Union[str, bytes],
-        value: Any,
-        *,
-        vivify_ttl: Optional[int] = None,
-    ) -> bool:
-        """Append value to an existing key. Returns True on success."""
-        key_bytes = self._to_bytes(key)
-        raw_value, client_flags = self._dump(key_bytes, value)
-        flags: List[bytes] = [b"MA", b"F%d" % client_flags]
-        if vivify_ttl is not None:
-            flags.append(b"N%d" % vivify_ttl)
-
-        command = MetaCommand(
-            cm=b"ms",
-            key=key_bytes,
-            datalen=len(raw_value),
-            flags=flags,
-            value=raw_value,
-        )
-        async with self._get_connection(key_bytes) as connection:
-            result = await connection.execute_meta_command(command)
-
-        if result.rc == b"HD":
-            return True
-        if result.rc == b"NS":
-            return False
-        raise MemcacheError(f"append failed: {result.rc.decode()}")
-
-    async def prepend(
-        self,
-        key: Union[str, bytes],
-        value: Any,
-        *,
-        vivify_ttl: Optional[int] = None,
-    ) -> bool:
-        """Prepend value to an existing key. Returns True on success."""
-        key_bytes = self._to_bytes(key)
-        raw_value, client_flags = self._dump(key_bytes, value)
-        flags: List[bytes] = [b"MP", b"F%d" % client_flags]
-        if vivify_ttl is not None:
-            flags.append(b"N%d" % vivify_ttl)
-
-        command = MetaCommand(
-            cm=b"ms",
-            key=key_bytes,
-            datalen=len(raw_value),
-            flags=flags,
-            value=raw_value,
-        )
-        async with self._get_connection(key_bytes) as connection:
-            result = await connection.execute_meta_command(command)
-
-        if result.rc == b"HD":
-            return True
-        if result.rc == b"NS":
-            return False
-        raise MemcacheError(f"prepend failed: {result.rc.decode()}")
+    async def replace(self, key: Key, value: Any, **options: Any) -> MutationResult:
+        options["condition"] = PRESENT
+        return await self.set(key, value, **options)
 
     async def cas(
+        self, key: Key, value: Any, cas_token: int, **options: Any
+    ) -> MutationResult:
+        options["condition"] = IfCas(cas_token)
+        return await self.set(key, value, **options)
+
+    async def append_bytes(
         self,
-        key: Union[str, bytes],
-        value: Any,
-        cas_token: int,
+        key: Key,
+        value: bytes,
         *,
-        expire: Optional[int] = None,
-    ) -> bool:
-        """Compare-and-swap. Returns True on success, False on CAS conflict."""
-        key_bytes = self._to_bytes(key)
-        raw_value, client_flags = self._dump(key_bytes, value)
-        flags: List[bytes] = [b"F%d" % client_flags, b"C%d" % cas_token]
-        if expire is not None:
-            flags.append(b"T%d" % expire)
-
-        command = MetaCommand(
-            cm=b"ms",
-            key=key_bytes,
-            datalen=len(raw_value),
-            flags=flags,
-            value=raw_value,
+        vivify_ttl: Optional[int] = None,
+        timeout: Optional[float] = None,
+    ) -> MutationResult:
+        if not isinstance(value, bytes):
+            raise TypeError("append_bytes requires bytes")
+        return await self._one(  # type: ignore[return-value]
+            Set(key, value, mode="append", vivify_ttl=vivify_ttl), timeout
         )
-        async with self._get_connection(key_bytes) as connection:
-            result = await connection.execute_meta_command(command)
 
-        if result.rc == b"HD":
-            return True
-        if result.rc in (b"EX", b"NF"):
-            return False
-        raise MemcacheError(f"cas failed: {result.rc.decode()}")
-
-    # ------------------------------------------------------------------ #
-    # Meta Delete (md)                                                   #
-    # ------------------------------------------------------------------ #
+    async def prepend_bytes(
+        self,
+        key: Key,
+        value: bytes,
+        *,
+        vivify_ttl: Optional[int] = None,
+        timeout: Optional[float] = None,
+    ) -> MutationResult:
+        if not isinstance(value, bytes):
+            raise TypeError("prepend_bytes requires bytes")
+        return await self._one(  # type: ignore[return-value]
+            Set(key, value, mode="prepend", vivify_ttl=vivify_ttl), timeout
+        )
 
     async def delete(
         self,
-        key: Union[str, bytes],
+        key: Key,
         *,
-        cas_token: Optional[int] = None,
-    ) -> bool:
-        """Delete a key. Returns True on success, False if key not found."""
-        key_bytes = self._to_bytes(key)
-        flags: List[bytes] = []
-        if cas_token is not None:
-            flags.append(b"C%d" % cas_token)
-
-        command = MetaCommand(cm=b"md", key=key_bytes, flags=flags)
-        async with self._get_connection(key_bytes) as connection:
-            result = await connection.execute_meta_command(command)
-
-        if result.rc == b"HD":
-            return True
-        if result.rc in (b"NF", b"EX"):
-            return False
-        raise MemcacheError(f"delete failed: {result.rc.decode()}")
+        condition: Optional[IfCas] = None,
+        timeout: Optional[float] = None,
+    ) -> MutationResult:
+        return await self._one(  # type: ignore[return-value]
+            Delete(key, condition), timeout
+        )
 
     async def invalidate(
         self,
-        key: Union[str, bytes],
+        key: Key,
         *,
-        stale_ttl: Optional[int] = None,
-        cas_token: Optional[int] = None,
-    ) -> bool:
-        """Mark a key as stale (stale-while-revalidate pattern)."""
-        key_bytes = self._to_bytes(key)
-        flags: List[bytes] = [b"I"]
-        if stale_ttl is not None:
-            flags.append(b"T%d" % stale_ttl)
-        if cas_token is not None:
-            flags.append(b"C%d" % cas_token)
+        stale_for: Optional[int] = None,
+        condition: Optional[IfCas] = None,
+        timeout: Optional[float] = None,
+    ) -> MutationResult:
+        return await self._one(  # type: ignore[return-value]
+            Delete(key, condition, invalidate=True, stale_for=stale_for), timeout
+        )
 
-        command = MetaCommand(cm=b"md", key=key_bytes, flags=flags)
-        async with self._get_connection(key_bytes) as connection:
-            result = await connection.execute_meta_command(command)
-
-        if result.rc == b"HD":
-            return True
-        if result.rc in (b"NF", b"EX"):
-            return False
-        raise MemcacheError(f"invalidate failed: {result.rc.decode()}")
-
-    # ------------------------------------------------------------------ #
-    # Meta Arithmetic (ma)                                               #
-    # ------------------------------------------------------------------ #
-
-    async def incr(
+    async def increment(
         self,
-        key: Union[str, bytes],
+        key: Key,
         delta: int = 1,
         *,
         initial: Optional[int] = None,
         initial_ttl: Optional[int] = None,
-        update_ttl: Optional[int] = None,
-    ) -> int:
-        """Increment counter. Raises MemcacheError if key missing and no initial."""
-        key_bytes = self._to_bytes(key)
-        flags: List[bytes] = [b"D%d" % delta, b"v"]
-        if initial is not None:
-            flags.append(b"J%d" % initial)
-            if initial_ttl is not None:
-                flags.append(b"N%d" % initial_ttl)
-        if update_ttl is not None:
-            flags.append(b"T%d" % update_ttl)
+        ttl: Optional[int] = None,
+        condition: Optional[IfCas] = None,
+        version: Optional[int] = None,
+        return_cas: bool = False,
+        timeout: Optional[float] = None,
+    ) -> ArithmeticResult:
+        return await self._one(  # type: ignore[return-value]
+            Increment(
+                key,
+                delta,
+                initial,
+                initial_ttl,
+                ttl,
+                False,
+                condition,
+                version,
+                return_cas,
+            ),
+            timeout,
+        )
 
-        command = MetaCommand(cm=b"ma", key=key_bytes, flags=flags)
-        async with self._get_connection(key_bytes) as connection:
-            result = await connection.execute_meta_command(command)
+    async def decrement(
+        self, key: Key, delta: int = 1, **options: Any
+    ) -> ArithmeticResult:
+        timeout = options.pop("timeout", None) if "timeout" in options else None
+        operation = Increment(key, delta=delta, decrement=True, **options)
+        return await self._one(operation, timeout)  # type: ignore[return-value]
 
-        if result.rc == b"NF":
-            raise MemcacheError("key not found")
-        if result.rc != b"VA":
-            raise MemcacheError(f"incr failed: {result.rc.decode()}")
-        if result.value is None:
-            raise MemcacheError("incr: no value returned")
-        return int(result.value)
-
-    async def decr(
-        self,
-        key: Union[str, bytes],
-        delta: int = 1,
-        *,
-        initial: Optional[int] = None,
-        initial_ttl: Optional[int] = None,
-        update_ttl: Optional[int] = None,
-    ) -> int:
-        """Decrement counter (floor 0). Raises MemcacheError if key missing."""
-        key_bytes = self._to_bytes(key)
-        flags: List[bytes] = [b"D%d" % delta, b"MD", b"v"]
-        if initial is not None:
-            flags.append(b"J%d" % initial)
-            if initial_ttl is not None:
-                flags.append(b"N%d" % initial_ttl)
-        if update_ttl is not None:
-            flags.append(b"T%d" % update_ttl)
-
-        command = MetaCommand(cm=b"ma", key=key_bytes, flags=flags)
-        async with self._get_connection(key_bytes) as connection:
-            result = await connection.execute_meta_command(command)
-
-        if result.rc == b"NF":
-            raise MemcacheError("key not found")
-        if result.rc != b"VA":
-            raise MemcacheError(f"decr failed: {result.rc.decode()}")
-        if result.value is None:
-            raise MemcacheError("decr: no value returned")
-        return int(result.value)
-
-    # ------------------------------------------------------------------ #
-    # Other                                                              #
-    # ------------------------------------------------------------------ #
+    async def touch(
+        self, key: Key, ttl: int, *, timeout: Optional[float] = None
+    ) -> MutationResult:
+        result = await self._one(Get(key, touch=ttl, value=False), timeout)
+        if isinstance(result, GetResult):
+            status = (
+                MutationStatus.STORED
+                if result.status is GetStatus.HIT
+                else (
+                    MutationStatus.NOT_FOUND
+                    if result.status is GetStatus.MISS
+                    else MutationStatus.FAILED
+                )
+            )
+            return MutationResult(key, status, error=result.error)
+        raise AssertionError("unexpected touch result")
 
     async def flush_all(self, delay: int = 0) -> None:
-        for pool in self._connections.nodes:
-            async with pool.get() as connection:
-                await connection.flush_all(delay)
+        _positive("delay", delay)
+        async with anyio.create_task_group() as tasks:
+            for server in self._servers:
+                tasks.start_soon(server.flush, delay)

--- a/memcache/experiment/meta_client.py
+++ b/memcache/experiment/meta_client.py
@@ -1,516 +1,261 @@
-from contextlib import contextmanager
-from typing import Any, Dict, Iterator, List, Optional, Union
+from __future__ import annotations
 
-import hashring
+import asyncio
+import concurrent.futures
+import threading
+from typing import Any, Coroutine, List, Optional, Sequence, TypeVar
 
-from ..connection import Addr, Connection, Pool
-from ..errors import MemcacheError
 from ..meta_command import MetaCommand, MetaResult
-from ..serialize import dump, load, DumpFunc, LoadFunc
-from .result import GetResult
+from .async_meta_client import AsyncMetaClient
+from .operation import ABSENT, PRESENT, Delete, Get, IfCas, Increment, Operation, Set
+from .result import (
+    ArithmeticResult,
+    BatchResult,
+    GetResult,
+    Key,
+    LeaseResult,
+    Meta,
+    MutationResult,
+)
 
 
-def _parse_flags(flags: List[bytes]) -> Dict[str, Any]:
-    result: Dict[str, Any] = {}
-    for flag in flags:
-        if not flag:
-            continue
-        prefix = chr(flag[0])
-        rest = flag[1:]
-        if prefix == "f":
-            result["client_flags"] = int(rest)
-        elif prefix == "c":
-            result["cas_token"] = int(rest)
-        elif prefix == "t":
-            result["ttl"] = int(rest)
-        elif prefix == "l":
-            result["last_access"] = int(rest)
-        elif prefix == "s":
-            result["size"] = int(rest)
-        elif prefix == "h":
-            result["hit_before"] = int(rest) != 0
-        elif prefix == "W":
-            result["won_recache"] = True
-        elif prefix == "X":
-            result["is_stale"] = True
-        elif prefix == "Z":
-            result["already_won"] = True
-        elif prefix == "k":
-            result["key"] = rest.decode("utf-8")
-    return result
+R = TypeVar("R")
+
+
+class RawClient:
+    def __init__(self, client: "MetaClient") -> None:
+        self._client = client
+
+    def execute(self, **command: Any) -> MetaResult:
+        return self._client._run(self._client._async.raw.execute(**command))
+
+    def batch(
+        self, commands: Sequence[MetaCommand], *, timeout: Optional[float] = None
+    ) -> List[MetaResult]:
+        return self._client._run(
+            self._client._async.raw.batch(commands, timeout=timeout)
+        )
 
 
 class MetaClient:
-    """
-    Memcache client with full meta protocol capability.
+    """Synchronous view over the sole async protocol implementation."""
 
-    Exposes the complete meta protocol (mg/ms/md/ma commands) with all flags.
-    Access via ``from memcache.experiment import MetaClient``.
-    """
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._ready = threading.Event()
+        self._thread = threading.Thread(
+            target=self._serve_loop,
+            name="memcache-meta-client",
+            daemon=True,
+        )
+        self._thread.start()
+        self._ready.wait()
+        self._async = AsyncMetaClient(*args, **kwargs)
+        self.raw = RawClient(self)
+        self._closed = False
 
-    def __init__(
+    def _serve_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._ready.set()
+        self._loop.run_forever()
+        self._loop.close()
+
+    def _run(self, awaitable: Coroutine[Any, Any, R]) -> R:
+        if self._closed:
+            if hasattr(awaitable, "close"):
+                awaitable.close()
+            raise RuntimeError("client is closed")
+        future: concurrent.futures.Future[R] = asyncio.run_coroutine_threadsafe(
+            awaitable, self._loop
+        )
+        return future.result()
+
+    def __enter__(self) -> "MetaClient":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._run(self._async.close())
+        self._closed = True
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join()
+
+    def execute_meta_command(
+        self, command: MetaCommand, *, timeout: Optional[float] = None
+    ) -> MetaResult:
+        return self._run(self._async.execute_meta_command(command, timeout=timeout))
+
+    def batch(
         self,
-        addr: Union[Addr, List[Addr], None] = None,
+        operations: Sequence[Operation],
         *,
-        pool_size: Optional[int] = 23,
-        pool_timeout: Optional[int] = 1,
-        load_func: LoadFunc = load,
-        dump_func: DumpFunc = dump,
-        username: Optional[str] = None,
-        password: Optional[str] = None,
-    ):
-        self._load = load_func
-        self._dump = dump_func
-
-        addr = addr or ("localhost", 11211)
-        if isinstance(addr, list):
-            addrs: List[Addr] = addr
-            nodes: List[Pool] = []
-            for a in addrs:
-                def _make(a: Addr = a) -> Connection:
-                    return Connection(
-                        a,
-                        username=username,
-                        password=password,
-                    )
-                nodes.append(Pool(_make, max_size=pool_size, timeout=pool_timeout))
-            self._connections = hashring.HashRing(nodes)
-        elif isinstance(addr, tuple):
-            a_single: Addr = addr
-
-            def _make_single() -> Connection:
-                return Connection(
-                    a_single,
-                    username=username,
-                    password=password,
-                )
-            self._connections = hashring.HashRing(
-                [Pool(_make_single, max_size=pool_size, timeout=pool_timeout)]
-            )
-        else:
-            raise TypeError("invalid type for addr")
-
-    @contextmanager
-    def _get_connection(self, key: Union[str, bytes]) -> Iterator[Connection]:
-        if isinstance(key, bytes):
-            # latin-1 maps every byte 1:1 so binary keys never raise here.
-            key = key.decode("latin-1")
-        pool = self._connections.get_node(key)
-        with pool.get() as connection:
-            yield connection
-
-    @staticmethod
-    def _to_bytes(key: Union[str, bytes]) -> bytes:
-        if isinstance(key, str):
-            return key.encode()
-        return key
-
-    def execute_meta_command(self, command: MetaCommand) -> MetaResult:
-        with self._get_connection(command.key) as connection:
-            return connection.execute_meta_command(command)
-
-    # ------------------------------------------------------------------ #
-    # Meta Get (mg)                                                      #
-    # ------------------------------------------------------------------ #
+        timeout: Optional[float] = None,
+    ) -> BatchResult:
+        return self._run(self._async.batch(operations, timeout=timeout))
 
     def get(
         self,
-        key: Union[str, bytes],
+        key: Key,
         *,
-        with_cas: bool = False,
-        with_ttl: bool = False,
-        with_last_access: bool = False,
-        with_size: bool = False,
-        with_hit_before: bool = False,
-        update_ttl: Optional[int] = None,
+        meta: Meta = Meta.NONE,
+        touch: Optional[int] = None,
         no_lru_bump: bool = False,
-        vivify_on_miss_ttl: Optional[int] = None,
-        recache_ttl_threshold: Optional[int] = None,
-        check_cas: Optional[int] = None,
-    ) -> Optional[GetResult[Any]]:
-        key_bytes = self._to_bytes(key)
-        flags: List[bytes] = [b"v", b"f"]
-        if with_cas:
-            flags.append(b"c")
-        if with_ttl:
-            flags.append(b"t")
-        if with_last_access:
-            flags.append(b"l")
-        if with_size:
-            flags.append(b"s")
-        if with_hit_before:
-            flags.append(b"h")
-        if update_ttl is not None:
-            flags.append(b"T%d" % update_ttl)
-        if no_lru_bump:
-            flags.append(b"u")
-        if vivify_on_miss_ttl is not None:
-            flags.append(b"N%d" % vivify_on_miss_ttl)
-        if recache_ttl_threshold is not None:
-            flags.append(b"R%d" % recache_ttl_threshold)
-        if check_cas is not None:
-            flags.append(b"C%d" % check_cas)
-
-        command = MetaCommand(cm=b"mg", key=key_bytes, flags=flags)
-        with self._get_connection(key_bytes) as connection:
-            result = connection.execute_meta_command(command)
-
-        if result.rc == b"EN":
-            return None
-
-        parsed = _parse_flags(result.flags)
-
-        gr: GetResult[Any] = GetResult()
-        gr.is_stale = parsed.get("is_stale", False)
-        gr.won_recache = parsed.get("won_recache", False)
-        gr.already_won = parsed.get("already_won", False)
-        if with_cas:
-            gr.cas_token = parsed.get("cas_token")
-        if with_ttl:
-            gr.ttl = parsed.get("ttl")
-        if with_last_access:
-            gr.last_access = parsed.get("last_access")
-        if with_size:
-            gr.size = parsed.get("size")
-        if with_hit_before:
-            gr.hit_before = parsed.get("hit_before")
-        if "key" in parsed:
-            gr.key = parsed["key"]
-
-        if result.value is not None and len(result.value) > 0:
-            client_flags = parsed.get("client_flags", 0)
-            gr.value = self._load(key_bytes, result.value, client_flags)
-
-        return gr
-
-    def touch(self, key: Union[str, bytes], expire: int) -> bool:
-        """Update the TTL of a key without returning its value."""
-        key_bytes = self._to_bytes(key)
-        command = MetaCommand(
-            cm=b"mg",
-            key=key_bytes,
-            flags=[b"T%d" % expire],
+        unless_cas: Optional[int] = None,
+        timeout: Optional[float] = None,
+    ) -> GetResult[Any]:
+        return self._run(
+            self._async.get(
+                key,
+                meta=meta,
+                touch=touch,
+                no_lru_bump=no_lru_bump,
+                unless_cas=unless_cas,
+                timeout=timeout,
+            )
         )
-        with self._get_connection(key_bytes) as connection:
-            result = connection.execute_meta_command(command)
-        return result.rc != b"EN"
+
+    def inspect(
+        self,
+        key: Key,
+        *,
+        meta: Meta = Meta.CAS | Meta.TTL | Meta.SIZE,
+        no_lru_bump: bool = True,
+        timeout: Optional[float] = None,
+    ) -> GetResult[Any]:
+        return self._run(
+            self._async.inspect(
+                key, meta=meta, no_lru_bump=no_lru_bump, timeout=timeout
+            )
+        )
+
+    def get_with_lease(
+        self,
+        key: Key,
+        *,
+        lease_ttl: int,
+        refresh_before: Optional[int] = None,
+        meta: Meta = Meta.NONE,
+        timeout: Optional[float] = None,
+    ) -> LeaseResult[Any]:
+        async_result = self._run(
+            self._async.get_with_lease(
+                key,
+                lease_ttl=lease_ttl,
+                refresh_before=refresh_before,
+                meta=meta,
+                timeout=timeout,
+            )
+        )
+        # Replace the async cursor callback with a blocking callback while
+        # retaining all response data.
+        async_fulfill = async_result._fulfill
+        async_result._fulfill = lambda *a, **kw: self._run(async_fulfill(*a, **kw))
+        return async_result
 
     def get_many(
         self,
-        keys: List[Union[str, bytes]],
-    ) -> Dict[str, GetResult[Any]]:
-        """Retrieve multiple keys; missing keys are omitted from the result."""
-        result: Dict[str, GetResult[Any]] = {}
-        for key in keys:
-            key_str = key if isinstance(key, str) else key.decode("latin-1")
-            gr = self.get(key)
-            if gr is not None:
-                result[key_str] = gr
-        return result
-
-    # ------------------------------------------------------------------ #
-    # Meta Set (ms)                                                      #
-    # ------------------------------------------------------------------ #
+        keys: Sequence[Key],
+        *,
+        meta: Meta = Meta.NONE,
+        timeout: Optional[float] = None,
+    ) -> BatchResult:
+        return self._run(self._async.get_many(keys, meta=meta, timeout=timeout))
 
     def set(
         self,
-        key: Union[str, bytes],
+        key: Key,
         value: Any,
         *,
-        expire: Optional[int] = None,
-    ) -> None:
-        key_bytes = self._to_bytes(key)
-        raw_value, client_flags = self._dump(key_bytes, value)
-        flags: List[bytes] = [b"F%d" % client_flags]
-        if expire is not None:
-            flags.append(b"T%d" % expire)
-
-        command = MetaCommand(
-            cm=b"ms",
-            key=key_bytes,
-            datalen=len(raw_value),
-            flags=flags,
-            value=raw_value,
+        ttl: Optional[int] = None,
+        condition: Any = None,
+        version: Optional[int] = None,
+        return_cas: bool = False,
+        timeout: Optional[float] = None,
+    ) -> MutationResult:
+        return self._run(
+            self._async.set(
+                key,
+                value,
+                ttl=ttl,
+                condition=condition,
+                version=version,
+                return_cas=return_cas,
+                timeout=timeout,
+            )
         )
-        with self._get_connection(key_bytes) as connection:
-            result = connection.execute_meta_command(command)
 
-        if result.rc != b"HD":
-            raise MemcacheError(f"set failed: {result.rc.decode()}")
+    def add(self, key: Key, value: Any, **options: Any) -> MutationResult:
+        options["condition"] = ABSENT
+        return self.set(key, value, **options)
 
-    def add(
-        self,
-        key: Union[str, bytes],
-        value: Any,
-        *,
-        expire: Optional[int] = None,
-    ) -> bool:
-        """Store only if key does not already exist. Returns True on success."""
-        key_bytes = self._to_bytes(key)
-        raw_value, client_flags = self._dump(key_bytes, value)
-        flags: List[bytes] = [b"ME", b"F%d" % client_flags]
-        if expire is not None:
-            flags.append(b"T%d" % expire)
-
-        command = MetaCommand(
-            cm=b"ms",
-            key=key_bytes,
-            datalen=len(raw_value),
-            flags=flags,
-            value=raw_value,
-        )
-        with self._get_connection(key_bytes) as connection:
-            result = connection.execute_meta_command(command)
-
-        if result.rc == b"HD":
-            return True
-        if result.rc == b"NS":
-            return False
-        raise MemcacheError(f"add failed: {result.rc.decode()}")
-
-    def replace(
-        self,
-        key: Union[str, bytes],
-        value: Any,
-        *,
-        expire: Optional[int] = None,
-    ) -> bool:
-        """Store only if key already exists. Returns True on success."""
-        key_bytes = self._to_bytes(key)
-        raw_value, client_flags = self._dump(key_bytes, value)
-        flags: List[bytes] = [b"MR", b"F%d" % client_flags]
-        if expire is not None:
-            flags.append(b"T%d" % expire)
-
-        command = MetaCommand(
-            cm=b"ms",
-            key=key_bytes,
-            datalen=len(raw_value),
-            flags=flags,
-            value=raw_value,
-        )
-        with self._get_connection(key_bytes) as connection:
-            result = connection.execute_meta_command(command)
-
-        if result.rc == b"HD":
-            return True
-        if result.rc == b"NS":
-            return False
-        raise MemcacheError(f"replace failed: {result.rc.decode()}")
-
-    def append(
-        self,
-        key: Union[str, bytes],
-        value: Any,
-        *,
-        vivify_ttl: Optional[int] = None,
-    ) -> bool:
-        """Append value to an existing key. Returns True on success."""
-        key_bytes = self._to_bytes(key)
-        raw_value, client_flags = self._dump(key_bytes, value)
-        flags: List[bytes] = [b"MA", b"F%d" % client_flags]
-        if vivify_ttl is not None:
-            flags.append(b"N%d" % vivify_ttl)
-
-        command = MetaCommand(
-            cm=b"ms",
-            key=key_bytes,
-            datalen=len(raw_value),
-            flags=flags,
-            value=raw_value,
-        )
-        with self._get_connection(key_bytes) as connection:
-            result = connection.execute_meta_command(command)
-
-        if result.rc == b"HD":
-            return True
-        if result.rc == b"NS":
-            return False
-        raise MemcacheError(f"append failed: {result.rc.decode()}")
-
-    def prepend(
-        self,
-        key: Union[str, bytes],
-        value: Any,
-        *,
-        vivify_ttl: Optional[int] = None,
-    ) -> bool:
-        """Prepend value to an existing key. Returns True on success."""
-        key_bytes = self._to_bytes(key)
-        raw_value, client_flags = self._dump(key_bytes, value)
-        flags: List[bytes] = [b"MP", b"F%d" % client_flags]
-        if vivify_ttl is not None:
-            flags.append(b"N%d" % vivify_ttl)
-
-        command = MetaCommand(
-            cm=b"ms",
-            key=key_bytes,
-            datalen=len(raw_value),
-            flags=flags,
-            value=raw_value,
-        )
-        with self._get_connection(key_bytes) as connection:
-            result = connection.execute_meta_command(command)
-
-        if result.rc == b"HD":
-            return True
-        if result.rc == b"NS":
-            return False
-        raise MemcacheError(f"prepend failed: {result.rc.decode()}")
+    def replace(self, key: Key, value: Any, **options: Any) -> MutationResult:
+        options["condition"] = PRESENT
+        return self.set(key, value, **options)
 
     def cas(
-        self,
-        key: Union[str, bytes],
-        value: Any,
-        cas_token: int,
-        *,
-        expire: Optional[int] = None,
-    ) -> bool:
-        """Compare-and-swap. Returns True on success, False on CAS conflict."""
-        key_bytes = self._to_bytes(key)
-        raw_value, client_flags = self._dump(key_bytes, value)
-        flags: List[bytes] = [b"F%d" % client_flags, b"C%d" % cas_token]
-        if expire is not None:
-            flags.append(b"T%d" % expire)
+        self, key: Key, value: Any, cas_token: int, **options: Any
+    ) -> MutationResult:
+        options["condition"] = IfCas(cas_token)
+        return self.set(key, value, **options)
 
-        command = MetaCommand(
-            cm=b"ms",
-            key=key_bytes,
-            datalen=len(raw_value),
-            flags=flags,
-            value=raw_value,
-        )
-        with self._get_connection(key_bytes) as connection:
-            result = connection.execute_meta_command(command)
+    def append_bytes(self, key: Key, value: bytes, **options: Any) -> MutationResult:
+        return self._run(self._async.append_bytes(key, value, **options))
 
-        if result.rc == b"HD":
-            return True
-        if result.rc in (b"EX", b"NF"):
-            return False
-        raise MemcacheError(f"cas failed: {result.rc.decode()}")
-
-    # ------------------------------------------------------------------ #
-    # Meta Delete (md)                                                   #
-    # ------------------------------------------------------------------ #
+    def prepend_bytes(self, key: Key, value: bytes, **options: Any) -> MutationResult:
+        return self._run(self._async.prepend_bytes(key, value, **options))
 
     def delete(
         self,
-        key: Union[str, bytes],
+        key: Key,
         *,
-        cas_token: Optional[int] = None,
-    ) -> bool:
-        """Delete a key. Returns True on success, False if key not found."""
-        key_bytes = self._to_bytes(key)
-        flags: List[bytes] = []
-        if cas_token is not None:
-            flags.append(b"C%d" % cas_token)
-
-        command = MetaCommand(cm=b"md", key=key_bytes, flags=flags)
-        with self._get_connection(key_bytes) as connection:
-            result = connection.execute_meta_command(command)
-
-        if result.rc == b"HD":
-            return True
-        if result.rc in (b"NF", b"EX"):
-            return False
-        raise MemcacheError(f"delete failed: {result.rc.decode()}")
+        condition: Optional[IfCas] = None,
+        timeout: Optional[float] = None,
+    ) -> MutationResult:
+        return self._run(self._async.delete(key, condition=condition, timeout=timeout))
 
     def invalidate(
         self,
-        key: Union[str, bytes],
+        key: Key,
         *,
-        stale_ttl: Optional[int] = None,
-        cas_token: Optional[int] = None,
-    ) -> bool:
-        """Mark a key as stale (stale-while-revalidate pattern)."""
-        key_bytes = self._to_bytes(key)
-        flags: List[bytes] = [b"I"]
-        if stale_ttl is not None:
-            flags.append(b"T%d" % stale_ttl)
-        if cas_token is not None:
-            flags.append(b"C%d" % cas_token)
+        stale_for: Optional[int] = None,
+        condition: Optional[IfCas] = None,
+        timeout: Optional[float] = None,
+    ) -> MutationResult:
+        return self._run(
+            self._async.invalidate(
+                key,
+                stale_for=stale_for,
+                condition=condition,
+                timeout=timeout,
+            )
+        )
 
-        command = MetaCommand(cm=b"md", key=key_bytes, flags=flags)
-        with self._get_connection(key_bytes) as connection:
-            result = connection.execute_meta_command(command)
+    def increment(self, key: Key, delta: int = 1, **options: Any) -> ArithmeticResult:
+        return self._run(self._async.increment(key, delta, **options))
 
-        if result.rc == b"HD":
-            return True
-        if result.rc in (b"NF", b"EX"):
-            return False
-        raise MemcacheError(f"invalidate failed: {result.rc.decode()}")
+    def decrement(self, key: Key, delta: int = 1, **options: Any) -> ArithmeticResult:
+        return self._run(self._async.decrement(key, delta, **options))
 
-    # ------------------------------------------------------------------ #
-    # Meta Arithmetic (ma)                                               #
-    # ------------------------------------------------------------------ #
-
-    def incr(
-        self,
-        key: Union[str, bytes],
-        delta: int = 1,
-        *,
-        initial: Optional[int] = None,
-        initial_ttl: Optional[int] = None,
-        update_ttl: Optional[int] = None,
-    ) -> int:
-        """Increment counter. Raises MemcacheError if key missing and no initial."""
-        key_bytes = self._to_bytes(key)
-        flags: List[bytes] = [b"D%d" % delta, b"v"]
-        if initial is not None:
-            flags.append(b"J%d" % initial)
-            if initial_ttl is not None:
-                flags.append(b"N%d" % initial_ttl)
-        if update_ttl is not None:
-            flags.append(b"T%d" % update_ttl)
-
-        command = MetaCommand(cm=b"ma", key=key_bytes, flags=flags)
-        with self._get_connection(key_bytes) as connection:
-            result = connection.execute_meta_command(command)
-
-        if result.rc == b"NF":
-            raise MemcacheError("key not found")
-        if result.rc != b"VA":
-            raise MemcacheError(f"incr failed: {result.rc.decode()}")
-        if result.value is None:
-            raise MemcacheError("incr: no value returned")
-        return int(result.value)
-
-    def decr(
-        self,
-        key: Union[str, bytes],
-        delta: int = 1,
-        *,
-        initial: Optional[int] = None,
-        initial_ttl: Optional[int] = None,
-        update_ttl: Optional[int] = None,
-    ) -> int:
-        """Decrement counter (floor 0). Raises MemcacheError if key missing."""
-        key_bytes = self._to_bytes(key)
-        flags: List[bytes] = [b"D%d" % delta, b"MD", b"v"]
-        if initial is not None:
-            flags.append(b"J%d" % initial)
-            if initial_ttl is not None:
-                flags.append(b"N%d" % initial_ttl)
-        if update_ttl is not None:
-            flags.append(b"T%d" % update_ttl)
-
-        command = MetaCommand(cm=b"ma", key=key_bytes, flags=flags)
-        with self._get_connection(key_bytes) as connection:
-            result = connection.execute_meta_command(command)
-
-        if result.rc == b"NF":
-            raise MemcacheError("key not found")
-        if result.rc != b"VA":
-            raise MemcacheError(f"decr failed: {result.rc.decode()}")
-        if result.value is None:
-            raise MemcacheError("decr: no value returned")
-        return int(result.value)
-
-    # ------------------------------------------------------------------ #
-    # Other                                                              #
-    # ------------------------------------------------------------------ #
+    def touch(
+        self, key: Key, ttl: int, *, timeout: Optional[float] = None
+    ) -> MutationResult:
+        return self._run(self._async.touch(key, ttl, timeout=timeout))
 
     def flush_all(self, delay: int = 0) -> None:
-        for pool in self._connections.nodes:
-            with pool.get() as connection:
-                connection.flush_all(delay)
+        self._run(self._async.flush_all(delay))
+
+
+__all__ = [
+    "ABSENT",
+    "PRESENT",
+    "Delete",
+    "Get",
+    "IfCas",
+    "Increment",
+    "MetaClient",
+    "Set",
+]

--- a/memcache/experiment/operation.py
+++ b/memcache/experiment/operation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from typing import Any, Optional, Union
 
@@ -47,7 +48,11 @@ class Get:
 @dataclass(frozen=True)
 class Set:
     key: Key
-    value: Any
+    if sys.version_info < (3, 9):
+        # Python 3.8's mypy rejects Any in dataclass-generated methods.
+        value: object
+    else:
+        value: Any
     ttl: Optional[int] = None
     condition: Optional[Condition] = None
     version: Optional[int] = None

--- a/memcache/experiment/operation.py
+++ b/memcache/experiment/operation.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Union
+
+from .result import Key, Meta
+
+
+class _Absent:
+    def __repr__(self) -> str:
+        return "ABSENT"
+
+
+class _Present:
+    def __repr__(self) -> str:
+        return "PRESENT"
+
+
+ABSENT = _Absent()
+PRESENT = _Present()
+
+
+@dataclass(frozen=True)
+class IfCas:
+    token: int
+
+    def __post_init__(self) -> None:
+        if self.token < 0:
+            raise ValueError("CAS token must be non-negative")
+
+
+Condition = Union[_Absent, _Present, IfCas]
+
+
+@dataclass(frozen=True)
+class Get:
+    key: Key
+    meta: Meta = Meta.NONE
+    touch: Optional[int] = None
+    no_lru_bump: bool = False
+    unless_cas: Optional[int] = None
+    value: bool = True
+    lease_ttl: Optional[int] = None
+    refresh_before: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class Set:
+    key: Key
+    value: Any
+    ttl: Optional[int] = None
+    condition: Optional[Condition] = None
+    version: Optional[int] = None
+    return_cas: bool = False
+    mode: str = "set"
+    vivify_ttl: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class Delete:
+    key: Key
+    condition: Optional[IfCas] = None
+    invalidate: bool = False
+    stale_for: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class Increment:
+    key: Key
+    delta: int = 1
+    initial: Optional[int] = None
+    initial_ttl: Optional[int] = None
+    ttl: Optional[int] = None
+    decrement: bool = False
+    condition: Optional[IfCas] = None
+    version: Optional[int] = None
+    return_cas: bool = False
+
+
+Operation = Union[Get, Set, Delete, Increment]

--- a/memcache/experiment/result.py
+++ b/memcache/experiment/result.py
@@ -1,19 +1,200 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Generic, Optional, TypeVar
+from enum import Enum, IntFlag, auto
+from typing import Any, Callable, Generic, Iterator, Optional, Sequence, TypeVar, Union
+
+from ..errors import MemcacheError
 
 
 T = TypeVar("T")
+Key = Union[str, bytes]
+_NO_VALUE = object()
 
 
-@dataclass
-class GetResult(Generic[T]):
-    value: Optional[T] = None
-    key: Optional[str] = None
-    cas_token: Optional[int] = None
+class GetStatus(Enum):
+    HIT = auto()
+    MISS = auto()
+    PENDING = auto()
+    UNCHANGED = auto()
+    FAILED = auto()
+    AMBIGUOUS = auto()
+
+
+class MutationStatus(Enum):
+    STORED = auto()
+    NOT_FOUND = auto()
+    ALREADY_EXISTS = auto()
+    CAS_MISMATCH = auto()
+    FAILED = auto()
+    AMBIGUOUS = auto()
+
+
+class ValueState(Enum):
+    FRESH = auto()
+    STALE = auto()
+    MISSING = auto()
+
+
+class LeaseState(Enum):
+    NONE = auto()
+    GRANTED = auto()
+    BUSY = auto()
+
+
+class Meta(IntFlag):
+    NONE = 0
+    CAS = 1 << 0
+    TTL = 1 << 1
+    SIZE = 1 << 2
+    LAST_ACCESS = 1 << 3
+    HIT_BEFORE = 1 << 4
+
+
+@dataclass(frozen=True)
+class ItemMeta:
+    cas: Optional[int] = None
     ttl: Optional[int] = None
-    last_access: Optional[int] = None
     size: Optional[int] = None
+    last_access: Optional[int] = None
     hit_before: Optional[bool] = None
-    is_stale: bool = False
-    won_recache: bool = False
-    already_won: bool = False
+
+
+class ResultValueError(MemcacheError):
+    """Raised when a result does not carry a usable value."""
+
+
+class GetResult(Generic[T]):
+    def __init__(
+        self,
+        *,
+        key: Key,
+        status: GetStatus,
+        value: Any = _NO_VALUE,
+        item: Optional[ItemMeta] = None,
+        value_state: ValueState = ValueState.MISSING,
+        lease_state: LeaseState = LeaseState.NONE,
+        error: Optional[BaseException] = None,
+    ) -> None:
+        self.key = key
+        self.status = status
+        self.item = item or ItemMeta()
+        self.value_state = value_state
+        self.lease_state = lease_state
+        self.error = error
+        self._value = value
+
+    @property
+    def value(self) -> T:
+        if self.status is not GetStatus.HIT or self._value is _NO_VALUE:
+            raise ResultValueError(
+                "value is only available on a HIT result which requested the value"
+            )
+        return self._value  # type: ignore[no-any-return]
+
+    def value_or(self, default: T) -> T:
+        if self.status is GetStatus.HIT and self._value is not _NO_VALUE:
+            return self._value  # type: ignore[no-any-return]
+        return default
+
+    def __bool__(self) -> bool:
+        return self.status is GetStatus.HIT
+
+    # Transitional metadata aliases. They cost nothing and make migration from
+    # the first experimental prototype less abrupt.
+    @property
+    def cas_token(self) -> Optional[int]:
+        return self.item.cas
+
+    @property
+    def ttl(self) -> Optional[int]:
+        return self.item.ttl
+
+    @property
+    def size(self) -> Optional[int]:
+        return self.item.size
+
+    @property
+    def last_access(self) -> Optional[int]:
+        return self.item.last_access
+
+    @property
+    def hit_before(self) -> Optional[bool]:
+        return self.item.hit_before
+
+    @property
+    def is_stale(self) -> bool:
+        return self.value_state is ValueState.STALE
+
+    @property
+    def won_recache(self) -> bool:
+        return self.lease_state is LeaseState.GRANTED
+
+    @property
+    def already_won(self) -> bool:
+        return self.lease_state is LeaseState.BUSY
+
+
+class LeaseResult(GetResult[T]):
+    def __init__(self, *, fulfill: Callable[..., Any], **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._fulfill = fulfill
+
+    def fulfill(
+        self,
+        value: T,
+        *,
+        ttl: Optional[int] = None,
+        version: Optional[int] = None,
+        return_cas: bool = False,
+        timeout: Optional[float] = None,
+    ) -> Any:
+        if self.lease_state is not LeaseState.GRANTED:
+            raise MemcacheError("only the lease winner can fulfill a refresh")
+        return self._fulfill(
+            value,
+            ttl=ttl,
+            version=version,
+            return_cas=return_cas,
+            timeout=timeout,
+        )
+
+
+@dataclass(frozen=True)
+class MutationResult:
+    key: Key
+    status: MutationStatus
+    cas: Optional[int] = None
+    error: Optional[BaseException] = None
+
+    def __bool__(self) -> bool:
+        return self.status is MutationStatus.STORED
+
+
+@dataclass(frozen=True)
+class ArithmeticResult:
+    key: Key
+    status: MutationStatus
+    value: Optional[int] = None
+    item: ItemMeta = ItemMeta()
+    error: Optional[BaseException] = None
+
+    def __bool__(self) -> bool:
+        return self.status is MutationStatus.STORED
+
+
+Result = Union[GetResult[Any], MutationResult, ArithmeticResult]
+
+
+class BatchResult(Sequence[Result]):
+    def __init__(self, results: Sequence[Result]) -> None:
+        self.results = tuple(results)
+
+    def __getitem__(self, index: Any) -> Any:
+        return self.results[index]
+
+    def __len__(self) -> int:
+        return len(self.results)
+
+    def __iter__(self) -> Iterator[Result]:
+        return iter(self.results)

--- a/memcache/memcache.py
+++ b/memcache/memcache.py
@@ -1,9 +1,12 @@
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
+import hashring
+
 from .connection import Addr, Connection, Pool  # re-export for backward compat
 from .errors import MemcacheError
 from .experiment.meta_client import MetaClient
+from .experiment.result import GetStatus, Meta, MutationStatus
 from .meta_command import MetaCommand, MetaResult
 from .serialize import dump, load, DumpFunc, LoadFunc
 
@@ -57,10 +60,22 @@ class Memcache:
             username=username,
             password=password,
         )
+        compat_addr = addr or ("localhost", 11211)
+        addresses = compat_addr if isinstance(compat_addr, list) else [compat_addr]
+        pools = []
+        for server in addresses:
+
+            def make(server: Addr = server) -> Connection:
+                return Connection(server, username=username, password=password)
+
+            pools.append(Pool(make, max_size=pool_size, timeout=pool_timeout))
+        self._compat_connections = hashring.HashRing(pools)
 
     @contextmanager
     def _get_connection(self, key: Union[str, bytes]) -> Iterator[Connection]:
-        with self._meta._get_connection(key) as conn:
+        routing_key = key if isinstance(key, str) else key.decode("latin-1")
+        pool = self._compat_connections.get_node(routing_key)
+        with pool.get() as conn:
             yield conn
 
     def execute_meta_command(self, command: MetaCommand) -> MetaResult:
@@ -72,11 +87,11 @@ class Memcache:
     def set(
         self, key: Union[bytes, str], value: Any, *, expire: Optional[int] = None
     ) -> None:
-        self._meta.set(key, value, expire=expire)
+        self._meta.set(key, value, ttl=expire)
 
     def get(self, key: Union[bytes, str]) -> Optional[Any]:
         r = self._meta.get(key)
-        return r.value if r is not None else None
+        return r.value if r.status is GetStatus.HIT else None
 
     def gets(self, key: Union[bytes, str]) -> Optional[Tuple[Any, int]]:
         """
@@ -85,8 +100,8 @@ class Memcache:
         :param key: The key to retrieve
         :return: A tuple of (value, cas_token) or None if key doesn't exist
         """
-        r = self._meta.get(key, with_cas=True)
-        if r is None:
+        r = self._meta.get(key, meta=Meta.CAS)
+        if r.status is not GetStatus.HIT:
             return None
         if r.cas_token is None:
             raise MemcacheError("CAS token not found in response")
@@ -109,38 +124,50 @@ class Memcache:
         :param expire: Optional expiration time in seconds
         :raises MemcacheError: If the CAS token doesn't match or other error occurs
         """
-        ok = self._meta.cas(key, value, cas_token, expire=expire)
-        if not ok:
+        result = self._meta.cas(key, value, cas_token, ttl=expire)
+        if result.status is not MutationStatus.STORED:
             raise MemcacheError("CAS operation failed: token mismatch or other error")
 
     def delete(self, key: Union[bytes, str]) -> bool:
-        return self._meta.delete(key)
+        return self._meta.delete(key).status is MutationStatus.STORED
 
     def touch(self, key: Union[bytes, str], expire: int) -> bool:
-        return self._meta.touch(key, expire)
+        return self._meta.touch(key, expire).status is MutationStatus.STORED
 
     def add(
         self, key: Union[bytes, str], value: Any, *, expire: Optional[int] = None
     ) -> bool:
-        return self._meta.add(key, value, expire=expire)
+        return self._meta.add(key, value, ttl=expire).status is MutationStatus.STORED
 
     def replace(
         self, key: Union[bytes, str], value: Any, *, expire: Optional[int] = None
     ) -> bool:
-        return self._meta.replace(key, value, expire=expire)
+        return (
+            self._meta.replace(key, value, ttl=expire).status is MutationStatus.STORED
+        )
 
     def append(self, key: Union[bytes, str], value: Any) -> bool:
-        return self._meta.append(key, value)
+        return self._meta.append_bytes(key, value).status is MutationStatus.STORED
 
     def prepend(self, key: Union[bytes, str], value: Any) -> bool:
-        return self._meta.prepend(key, value)
+        return self._meta.prepend_bytes(key, value).status is MutationStatus.STORED
 
     def get_many(self, keys: List[Union[bytes, str]]) -> Dict[str, Any]:
         results = self._meta.get_many(keys)
-        return {k: v.value for k, v in results.items()}
+        return {
+            r.key if isinstance(r.key, str) else r.key.decode("latin-1"): r.value
+            for r in results
+            if r.status is GetStatus.HIT
+        }
 
     def incr(self, key: Union[bytes, str], value: int = 1) -> int:
-        return self._meta.incr(key, value)
+        result = self._meta.increment(key, value)
+        if result.status is not MutationStatus.STORED or result.value is None:
+            raise MemcacheError("key not found")
+        return result.value
 
     def decr(self, key: Union[bytes, str], value: int = 1) -> int:
-        return self._meta.decr(key, value)
+        result = self._meta.decrement(key, value)
+        if result.status is not MutationStatus.STORED or result.value is None:
+            raise MemcacheError("key not found")
+        return result.value

--- a/memcache/meta_command.py
+++ b/memcache/meta_command.py
@@ -73,6 +73,12 @@ class MetaCommand:
             header = b" ".join([self.cm, wire_key, datalen] + flags + [b"\r\n"])
         return header
 
+    def dump(self) -> bytes:
+        payload = self.dump_header()
+        if self.value is not None:
+            payload += self.value + b"\r\n"
+        return payload
+
 
 @dataclass
 class MetaResult:
@@ -91,7 +97,7 @@ class MetaResult:
             prefix = rc + b" "
             # Use ``line.removeprefix(prefix)`` when dropping Python 3.8 support.
             if line.startswith(prefix):
-                line = line[len(prefix) :]
+                line = line[len(prefix) :]  # noqa: E203
             raise MemcacheError(line.rstrip().decode("utf-8"))
 
         flags = []

--- a/tests/test_async_meta_client.py
+++ b/tests/test_async_meta_client.py
@@ -1,452 +1,103 @@
-import asyncio
-
 import pytest
 import pytest_asyncio
 
-from memcache.experiment import AsyncMetaClient, GetResult
-from memcache import MemcacheError
-from memcache.meta_command import MetaCommand
+from memcache.async_connection import PipelineError
+from memcache.experiment import (
+    AmbiguousWriteError,
+    AsyncMetaClient,
+    Get,
+    GetStatus,
+    LeaseState,
+    Meta,
+    MutationStatus,
+    Set,
+    ValueState,
+)
 
 
 @pytest.fixture()
-def client() -> AsyncMetaClient:
+def client():
     return AsyncMetaClient(("localhost", 11211))
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def flush(client: AsyncMetaClient) -> None:
+async def flush(client):
     await client.flush_all()
-
-
-# ------------------------------------------------------------------ #
-# get / set                                                             #
-# ------------------------------------------------------------------ #
+    yield
+    await client.close()
 
 
 @pytest.mark.asyncio
-async def test_set_get(client: AsyncMetaClient) -> None:
-    await client.set("key1", "hello")
-    r = await client.get("key1")
-    assert r is not None
-    assert r.value == "hello"
+async def test_async_api_has_the_same_shape(client):
+    stored = await client.set("key", {"value": 1}, ttl=60, return_cas=True)
+    assert stored.status is MutationStatus.STORED
+    assert stored.cas is not None
+
+    result = await client.get("key", meta=Meta.CAS | Meta.TTL)
+    assert result.status is GetStatus.HIT
+    assert result.value == {"value": 1}
+    assert result.item.cas == stored.cas
+
+    unchanged = await client.get("key", unless_cas=stored.cas)
+    assert unchanged.status is GetStatus.UNCHANGED
+
+    batch = await client.batch([Get("key"), Get("missing"), Set("other", b"x")])
+    assert [item.status for item in batch] == [
+        GetStatus.HIT,
+        GetStatus.MISS,
+        MutationStatus.STORED,
+    ]
 
 
 @pytest.mark.asyncio
-async def test_get_missing(client: AsyncMetaClient) -> None:
-    assert await client.get("no_such_key") is None
+async def test_async_lease_cursor(client):
+    winner = await client.get_with_lease("lease", lease_ttl=30)
+    loser = await client.get_with_lease("lease", lease_ttl=30)
+    assert winner.value_state is ValueState.MISSING
+    assert winner.lease_state is LeaseState.GRANTED
+    assert loser.lease_state is LeaseState.BUSY
+
+    fulfilled = await winner.fulfill("ready", ttl=60)
+    assert fulfilled.status is MutationStatus.STORED
+    assert (await client.get("lease")).value == "ready"
 
 
 @pytest.mark.asyncio
-async def test_set_get_with_expire(client: AsyncMetaClient) -> None:
-    await client.set("expkey", "val", expire=1)
-    r = await client.get("expkey")
-    assert r is not None
-    assert r.value == "val"
-    await asyncio.sleep(1.1)
-    assert await client.get("expkey") is None
+async def test_batch_marks_written_side_effects_ambiguous(monkeypatch):
+    client = AsyncMetaClient(("localhost", 11211))
+
+    async def fail(commands, timeout):
+        raise PipelineError(2, [], ConnectionResetError("lost"))
+
+    monkeypatch.setattr(client._servers[0], "pipeline", fail)
+    results = await client.batch([Set("a", "v"), Get("b"), Set("c", "v")])
+    assert results[0].status is MutationStatus.AMBIGUOUS
+    assert results[1].status is GetStatus.FAILED
+    assert results[2].status is MutationStatus.FAILED
+
+    with pytest.raises(AmbiguousWriteError):
+        await client.set("a", "v")
+    await client.close()
 
 
 @pytest.mark.asyncio
-async def test_get_returns_getresult_instance(client: AsyncMetaClient) -> None:
-    await client.set("gr_type", 42)
-    r = await client.get("gr_type")
-    assert isinstance(r, GetResult)
-    assert r.value == 42
-
-
-@pytest.mark.asyncio
-async def test_get_no_lru_bump(client: AsyncMetaClient) -> None:
-    await client.set("nlb", "v")
-    r = await client.get("nlb", no_lru_bump=True)
-    assert r is not None
-    assert r.value == "v"
-
-
-@pytest.mark.asyncio
-async def test_get_update_ttl(client: AsyncMetaClient) -> None:
-    await client.set("utt", "v", expire=10)
-    r = await client.get("utt", update_ttl=3600)
-    assert r is not None
-    assert r.value == "v"
-
-
-@pytest.mark.asyncio
-async def test_get_with_cas(client: AsyncMetaClient) -> None:
-    await client.set("gr_cas", "v")
-    r = await client.get("gr_cas", with_cas=True)
-    assert r is not None
-    assert isinstance(r.cas_token, int)
-    assert r.cas_token > 0
-
-
-@pytest.mark.asyncio
-async def test_get_with_ttl(client: AsyncMetaClient) -> None:
-    await client.set("gr_ttl", "v", expire=3600)
-    r = await client.get("gr_ttl", with_ttl=True)
-    assert r is not None
-    assert r.ttl is not None
-    assert r.ttl > 0
-
-
-@pytest.mark.asyncio
-async def test_get_no_ttl_requested(client: AsyncMetaClient) -> None:
-    await client.set("gr_nottl", "v")
-    r = await client.get("gr_nottl")
-    assert r is not None
-    assert r.ttl is None
-
-
-@pytest.mark.asyncio
-async def test_get_with_size(client: AsyncMetaClient) -> None:
-    await client.set("gr_size", b"hello")
-    r = await client.get("gr_size", with_size=True)
-    assert r is not None
-    assert r.size == 5
-
-
-@pytest.mark.asyncio
-async def test_get_with_hit_before(client: AsyncMetaClient) -> None:
-    await client.set("gr_hit", "v")
-    r1 = await client.get("gr_hit", with_hit_before=True)
-    assert r1 is not None
-    assert r1.hit_before is False
-    r2 = await client.get("gr_hit", with_hit_before=True)
-    assert r2 is not None
-    assert r2.hit_before is True
-
-
-@pytest.mark.asyncio
-async def test_get_with_last_access(client: AsyncMetaClient) -> None:
-    await client.set("gr_la", "v")
-    r = await client.get("gr_la", with_last_access=True)
-    assert r is not None
-    assert r.last_access is not None
-    assert isinstance(r.last_access, int)
-
-
-# ------------------------------------------------------------------ #
-# touch                                                                 #
-# ------------------------------------------------------------------ #
-
-
-@pytest.mark.asyncio
-async def test_touch_existing(client: AsyncMetaClient) -> None:
-    await client.set("touch_key", "v", expire=1)
-    assert await client.touch("touch_key", expire=3600) is True
-    await asyncio.sleep(1.1)
-    r = await client.get("touch_key")
-    assert r is not None
-    assert r.value == "v"
-
-
-@pytest.mark.asyncio
-async def test_touch_missing(client: AsyncMetaClient) -> None:
-    assert await client.touch("no_touch_key", expire=60) is False
-
-
-# ------------------------------------------------------------------ #
-# get_many                                                              #
-# ------------------------------------------------------------------ #
-
-
-@pytest.mark.asyncio
-async def test_get_many(client: AsyncMetaClient) -> None:
-    await client.set("m1", "a")
-    await client.set("m2", "b")
-    result = await client.get_many(["m1", "m2", "m_miss"])
-    assert set(result.keys()) == {"m1", "m2"}
-    assert result["m1"].value == "a"
-    assert result["m2"].value == "b"
-
-
-@pytest.mark.asyncio
-async def test_get_many_all_miss(client: AsyncMetaClient) -> None:
-    assert await client.get_many(["x1", "x2"]) == {}
-
-
-# ------------------------------------------------------------------ #
-# add / replace                                                         #
-# ------------------------------------------------------------------ #
-
-
-@pytest.mark.asyncio
-async def test_add_new_key(client: AsyncMetaClient) -> None:
-    assert await client.add("add_new", "v") is True
-    r = await client.get("add_new")
-    assert r is not None
-    assert r.value == "v"
-
-
-@pytest.mark.asyncio
-async def test_add_existing_key(client: AsyncMetaClient) -> None:
-    await client.set("add_exists", "original")
-    assert await client.add("add_exists", "new") is False
-    r = await client.get("add_exists")
-    assert r is not None
-    assert r.value == "original"
-
-
-@pytest.mark.asyncio
-async def test_replace_existing(client: AsyncMetaClient) -> None:
-    await client.set("rep_key", "old")
-    assert await client.replace("rep_key", "new") is True
-    r = await client.get("rep_key")
-    assert r is not None
-    assert r.value == "new"
-
-
-@pytest.mark.asyncio
-async def test_replace_missing(client: AsyncMetaClient) -> None:
-    assert await client.replace("rep_miss", "v") is False
-
-
-# ------------------------------------------------------------------ #
-# append / prepend                                                      #
-# ------------------------------------------------------------------ #
-
-
-@pytest.mark.asyncio
-async def test_append(client: AsyncMetaClient) -> None:
-    await client.set("app_key", b"hello")
-    assert await client.append("app_key", b" world") is True
-    r = await client.get("app_key")
-    assert r is not None
-    assert r.value == b"hello world"
-
-
-@pytest.mark.asyncio
-async def test_append_missing_key(client: AsyncMetaClient) -> None:
-    assert await client.append("app_miss", b"v") is False
-
-
-@pytest.mark.asyncio
-async def test_append_vivify(client: AsyncMetaClient) -> None:
-    assert await client.append("app_vivify", b"data", vivify_ttl=60) is True
-    r = await client.get("app_vivify")
-    assert r is not None
-    assert r.value == b"data"
-
-
-@pytest.mark.asyncio
-async def test_prepend(client: AsyncMetaClient) -> None:
-    await client.set("pre_key", b"world")
-    assert await client.prepend("pre_key", b"hello ") is True
-    r = await client.get("pre_key")
-    assert r is not None
-    assert r.value == b"hello world"
-
-
-@pytest.mark.asyncio
-async def test_prepend_missing_key(client: AsyncMetaClient) -> None:
-    assert await client.prepend("pre_miss", b"v") is False
-
-
-@pytest.mark.asyncio
-async def test_prepend_vivify(client: AsyncMetaClient) -> None:
-    assert await client.prepend("pre_vivify", b"data", vivify_ttl=60) is True
-    r = await client.get("pre_vivify")
-    assert r is not None
-    assert r.value == b"data"
-
-
-# ------------------------------------------------------------------ #
-# cas                                                                   #
-# ------------------------------------------------------------------ #
-
-
-@pytest.mark.asyncio
-async def test_cas_success(client: AsyncMetaClient) -> None:
-    await client.set("cas_key", "initial")
-    r = await client.get("cas_key", with_cas=True)
-    assert r is not None
-    assert r.cas_token is not None
-    assert await client.cas("cas_key", "updated", r.cas_token) is True
-    r2 = await client.get("cas_key")
-    assert r2 is not None
-    assert r2.value == "updated"
-
-
-@pytest.mark.asyncio
-async def test_cas_conflict(client: AsyncMetaClient) -> None:
-    await client.set("cas_conf", "v")
-    r = await client.get("cas_conf", with_cas=True)
-    assert r is not None
-    assert r.cas_token is not None
-    await client.set("cas_conf", "modified")
-    assert await client.cas("cas_conf", "new", r.cas_token) is False
-    r2 = await client.get("cas_conf")
-    assert r2 is not None
-    assert r2.value == "modified"
-
-
-@pytest.mark.asyncio
-async def test_cas_missing_key(client: AsyncMetaClient) -> None:
-    assert await client.cas("cas_no_key", "v", 12345) is False
-
-
-# ------------------------------------------------------------------ #
-# delete                                                                #
-# ------------------------------------------------------------------ #
-
-
-@pytest.mark.asyncio
-async def test_delete_existing(client: AsyncMetaClient) -> None:
-    await client.set("del_key", "v")
-    assert await client.delete("del_key") is True
-    assert await client.get("del_key") is None
-
-
-@pytest.mark.asyncio
-async def test_delete_missing(client: AsyncMetaClient) -> None:
-    assert await client.delete("del_miss") is False
-
-
-@pytest.mark.asyncio
-async def test_delete_with_cas(client: AsyncMetaClient) -> None:
-    await client.set("del_cas", "v")
-    r = await client.get("del_cas", with_cas=True)
-    assert r is not None
-    assert r.cas_token is not None
-    assert await client.delete("del_cas", cas_token=r.cas_token) is True
-
-
-@pytest.mark.asyncio
-async def test_delete_with_wrong_cas(client: AsyncMetaClient) -> None:
-    await client.set("del_cas_bad", "v")
-    assert await client.delete("del_cas_bad", cas_token=99999999) is False
-
-
-# ------------------------------------------------------------------ #
-# invalidate                                                            #
-# ------------------------------------------------------------------ #
-
-
-@pytest.mark.asyncio
-async def test_invalidate(client: AsyncMetaClient) -> None:
-    await client.set("inv_key", "v")
-    assert await client.invalidate("inv_key") is True
-
-
-@pytest.mark.asyncio
-async def test_invalidate_missing(client: AsyncMetaClient) -> None:
-    assert await client.invalidate("inv_miss") is False
-
-
-@pytest.mark.asyncio
-async def test_invalidate_stale_flag(client: AsyncMetaClient) -> None:
-    await client.set("inv_stale", "v")
-    await client.invalidate("inv_stale", stale_ttl=10)
-    r = await client.get("inv_stale")
-    assert r is not None
-    assert r.is_stale is True
-
-
-# ------------------------------------------------------------------ #
-# incr / decr                                                           #
-# ------------------------------------------------------------------ #
-
-
-@pytest.mark.asyncio
-async def test_incr(client: AsyncMetaClient) -> None:
-    await client.set("ctr", 10)
-    assert await client.incr("ctr") == 11
-
-
-@pytest.mark.asyncio
-async def test_incr_with_delta(client: AsyncMetaClient) -> None:
-    await client.set("ctr2", 5)
-    assert await client.incr("ctr2", 3) == 8
-
-
-@pytest.mark.asyncio
-async def test_incr_missing(client: AsyncMetaClient) -> None:
-    with pytest.raises(MemcacheError):
-        await client.incr("incr_miss")
-
-
-@pytest.mark.asyncio
-async def test_incr_with_initial(client: AsyncMetaClient) -> None:
-    # On miss with J flag, memcached creates item with initial value (delta not applied)
-    assert await client.incr("incr_init", initial=100, initial_ttl=60) == 100
-
-
-@pytest.mark.asyncio
-async def test_incr_with_initial_existing(client: AsyncMetaClient) -> None:
-    await client.set("incr_init_ex", 5)
-    assert await client.incr("incr_init_ex", initial=100, initial_ttl=60) == 6
-
-
-@pytest.mark.asyncio
-async def test_decr(client: AsyncMetaClient) -> None:
-    await client.set("dctr", 10)
-    assert await client.decr("dctr") == 9
-
-
-@pytest.mark.asyncio
-async def test_decr_with_delta(client: AsyncMetaClient) -> None:
-    await client.set("dctr2", 10)
-    assert await client.decr("dctr2", 3) == 7
-
-
-@pytest.mark.asyncio
-async def test_decr_floor_zero(client: AsyncMetaClient) -> None:
-    await client.set("dctr3", 1)
-    assert await client.decr("dctr3", 5) == 0
-
-
-@pytest.mark.asyncio
-async def test_decr_missing(client: AsyncMetaClient) -> None:
-    with pytest.raises(MemcacheError):
-        await client.decr("decr_miss")
-
-
-@pytest.mark.asyncio
-async def test_decr_with_initial(client: AsyncMetaClient) -> None:
-    result = await client.decr("decr_init", initial=50, initial_ttl=60)
-    # On miss with J flag, memcached creates item with initial value (delta not applied)
-    assert result == 50
-
-
-# ------------------------------------------------------------------ #
-# flush_all                                                             #
-# ------------------------------------------------------------------ #
-
-
-@pytest.mark.asyncio
-async def test_flush_all(client: AsyncMetaClient) -> None:
-    await client.set("flush_k", "v")
-    await client.flush_all()
-    assert await client.get("flush_k") is None
-
-
-# ------------------------------------------------------------------ #
-# execute_meta_command (low-level pass-through)                         #
-# ------------------------------------------------------------------ #
-
-
-@pytest.mark.asyncio
-async def test_execute_meta_command(client: AsyncMetaClient) -> None:
-    cmd = MetaCommand(
-        cm=b"ms", key=b"raw_key", datalen=3, flags=[b"T60"], value=b"raw"
-    )
-    result = await client.execute_meta_command(cmd)
-    assert result.rc == b"HD"
-
-    cmd2 = MetaCommand(cm=b"mg", key=b"raw_key", flags=[b"v"])
-    result2 = await client.execute_meta_command(cmd2)
-    assert result2.rc == b"VA"
-    assert result2.value == b"raw"
-
-
-# ------------------------------------------------------------------ #
-# Non-legacy keys: base64 encoding on the wire (b flag)              #
-# ------------------------------------------------------------------ #
-
-
-@pytest.mark.asyncio
-async def test_set_get_non_legacy_key(client: AsyncMetaClient) -> None:
-    # End-to-end: the server accepts our base64 + `b` wire format and routing.
-    await client.set(b"crlf\r\ninjection", "payload")
-    r = await client.get(b"crlf\r\ninjection")
-    assert r is not None
-    assert r.value == "payload"
+async def test_server_failure_is_isolated_in_batch():
+    client = AsyncMetaClient([("localhost", 11211), ("localhost", 1)], timeout=0.2)
+    good = bad = None
+    for number in range(10000):
+        key = "shard-%d" % number
+        port = client._server_for(key).addr[1]
+        if port == 11211 and good is None:
+            good = key
+        elif port == 1 and bad is None:
+            bad = key
+        if good is not None and bad is not None:
+            break
+    assert good is not None and bad is not None
+
+    results = await client.batch([Set(good, "ok"), Set(bad, "no"), Get(good)])
+    assert results[0].status is MutationStatus.STORED
+    assert results[1].status is MutationStatus.FAILED
+    assert results[2].status is GetStatus.HIT
+    assert results[2].value == "ok"
+    await client.close()

--- a/tests/test_meta_client.py
+++ b/tests/test_meta_client.py
@@ -1,470 +1,212 @@
-import base64
-import time
-
 import pytest
 
-from memcache.experiment import GetResult, MetaClient
-from memcache import MemcacheError
-from memcache.meta_command import MetaCommand, MetaResult, encode_key
+from memcache import MetaCommand
+from memcache.experiment import (
+    ABSENT,
+    ArithmeticResult,
+    Delete,
+    Get,
+    GetStatus,
+    IfCas,
+    Increment,
+    LeaseState,
+    Meta,
+    MetaClient,
+    MutationStatus,
+    ResultValueError,
+    Set,
+    ValueState,
+)
 
 
 @pytest.fixture()
-def client() -> MetaClient:
-    c = MetaClient(("localhost", 11211))
-    c.flush_all()
-    return c
-
-
-# ------------------------------------------------------------------ #
-# Bug fix: load_header correctly parses flags after datalen          #
-# ------------------------------------------------------------------ #
-
-
-def test_load_header_with_flags_after_datalen() -> None:
-    # HD with flag containing non-digit prefix should NOT be parsed as datalen
-    result = MetaResult.load_header(b"HD t20 c123\r\n")
-    assert result.rc == b"HD"
-    assert result.datalen is None
-    assert b"t20" in result.flags
-    assert b"c123" in result.flags
-
-
-def test_load_header_va_with_datalen_and_flags() -> None:
-    result = MetaResult.load_header(b"VA 5 f16 c999\r\n")
-    assert result.rc == b"VA"
-    assert result.datalen == 5
-    assert b"f16" in result.flags
-    assert b"c999" in result.flags
-
-
-def test_load_header_en() -> None:
-    result = MetaResult.load_header(b"EN\r\n")
-    assert result.rc == b"EN"
-    assert result.datalen is None
-    assert result.flags == []
-
-
-def test_load_header_client_error_preserves_message_prefix() -> None:
-    with pytest.raises(MemcacheError, match="^Invalid arguments$"):
-        MetaResult.load_header(b"CLIENT_ERROR Invalid arguments\r\n")
-
-
-def test_load_header_server_error() -> None:
-    with pytest.raises(MemcacheError, match="^Temporary failure$"):
-        MetaResult.load_header(b"SERVER_ERROR Temporary failure\r\n")
-
-
-# ------------------------------------------------------------------ #
-# get / set                                                          #
-# ------------------------------------------------------------------ #
-
-
-def test_set_get(client: MetaClient) -> None:
-    client.set("key1", "hello")
-    r = client.get("key1")
-    assert r is not None
-    assert r.value == "hello"
-
-
-def test_get_missing(client: MetaClient) -> None:
-    assert client.get("no_such_key") is None
-
-
-def test_set_get_with_expire(client: MetaClient) -> None:
-    client.set("expkey", "val", expire=1)
-    r = client.get("expkey")
-    assert r is not None
-    assert r.value == "val"
-    time.sleep(1.1)
-    assert client.get("expkey") is None
-
-
-def test_get_returns_getresult_instance(client: MetaClient) -> None:
-    client.set("gr_type", 42)
-    r = client.get("gr_type")
-    assert isinstance(r, GetResult)
-    assert r.value == 42
-
-
-def test_get_no_lru_bump(client: MetaClient) -> None:
-    client.set("nlb", "v")
-    r = client.get("nlb", no_lru_bump=True)
-    assert r is not None
-    assert r.value == "v"
-
-
-def test_get_update_ttl(client: MetaClient) -> None:
-    client.set("utt", "v", expire=10)
-    r = client.get("utt", update_ttl=3600)
-    assert r is not None
-    assert r.value == "v"
-
-
-def test_get_with_cas(client: MetaClient) -> None:
-    client.set("gr_cas", "v")
-    r = client.get("gr_cas", with_cas=True)
-    assert r is not None
-    assert isinstance(r.cas_token, int)
-    assert r.cas_token > 0
-
-
-def test_get_with_ttl(client: MetaClient) -> None:
-    client.set("gr_ttl", "v", expire=3600)
-    r = client.get("gr_ttl", with_ttl=True)
-    assert r is not None
-    assert r.ttl is not None
-    assert r.ttl > 0
-
-
-def test_get_no_ttl_requested(client: MetaClient) -> None:
-    client.set("gr_nottl", "v")
-    r = client.get("gr_nottl")
-    assert r is not None
-    assert r.ttl is None
-
-
-def test_get_with_size(client: MetaClient) -> None:
-    client.set("gr_size", b"hello")
-    r = client.get("gr_size", with_size=True)
-    assert r is not None
-    assert r.size == 5
-
-
-def test_get_with_hit_before(client: MetaClient) -> None:
-    client.set("gr_hit", "v")
-    # First get: not hit before
-    r1 = client.get("gr_hit", with_hit_before=True)
-    assert r1 is not None
-    assert r1.hit_before is False
-    # Second get: hit before
-    r2 = client.get("gr_hit", with_hit_before=True)
-    assert r2 is not None
-    assert r2.hit_before is True
-
-
-def test_get_with_last_access(client: MetaClient) -> None:
-    client.set("gr_la", "v")
-    r = client.get("gr_la", with_last_access=True)
-    assert r is not None
-    assert r.last_access is not None
-    assert isinstance(r.last_access, int)
-
-
-# ------------------------------------------------------------------ #
-# touch                                                              #
-# ------------------------------------------------------------------ #
-
-
-def test_touch_existing(client: MetaClient) -> None:
-    client.set("touch_key", "v", expire=1)
-    assert client.touch("touch_key", expire=3600) is True
-    time.sleep(1.1)
-    r = client.get("touch_key")
-    assert r is not None
-    assert r.value == "v"
-
-
-def test_touch_missing(client: MetaClient) -> None:
-    assert client.touch("no_touch_key", expire=60) is False
-
-
-# ------------------------------------------------------------------ #
-# get_many                                                           #
-# ------------------------------------------------------------------ #
-
-
-def test_get_many(client: MetaClient) -> None:
-    client.set("m1", "a")
-    client.set("m2", "b")
-    result = client.get_many(["m1", "m2", "m_miss"])
-    assert set(result.keys()) == {"m1", "m2"}
-    assert result["m1"].value == "a"
-    assert result["m2"].value == "b"
-
-
-def test_get_many_all_miss(client: MetaClient) -> None:
-    assert client.get_many(["x1", "x2"]) == {}
-
-
-# ------------------------------------------------------------------ #
-# add / replace                                                      #
-# ------------------------------------------------------------------ #
-
-
-def test_add_new_key(client: MetaClient) -> None:
-    assert client.add("add_new", "v") is True
-    r = client.get("add_new")
-    assert r is not None
-    assert r.value == "v"
-
-
-def test_add_existing_key(client: MetaClient) -> None:
-    client.set("add_exists", "original")
-    assert client.add("add_exists", "new") is False
-    r = client.get("add_exists")
-    assert r is not None
-    assert r.value == "original"
-
-
-def test_replace_existing(client: MetaClient) -> None:
-    client.set("rep_key", "old")
-    assert client.replace("rep_key", "new") is True
-    r = client.get("rep_key")
-    assert r is not None
-    assert r.value == "new"
-
-
-def test_replace_missing(client: MetaClient) -> None:
-    assert client.replace("rep_miss", "v") is False
-
-
-# ------------------------------------------------------------------ #
-# append / prepend                                                   #
-# ------------------------------------------------------------------ #
-
-
-def test_append(client: MetaClient) -> None:
-    client.set("app_key", b"hello")
-    assert client.append("app_key", b" world") is True
-    r = client.get("app_key")
-    assert r is not None
-    assert r.value == b"hello world"
-
-
-def test_append_missing_key(client: MetaClient) -> None:
-    assert client.append("app_miss", b"v") is False
-
-
-def test_append_vivify(client: MetaClient) -> None:
-    assert client.append("app_vivify", b"data", vivify_ttl=60) is True
-    r = client.get("app_vivify")
-    assert r is not None
-    assert r.value == b"data"
-
-
-def test_prepend(client: MetaClient) -> None:
-    client.set("pre_key", b"world")
-    assert client.prepend("pre_key", b"hello ") is True
-    r = client.get("pre_key")
-    assert r is not None
-    assert r.value == b"hello world"
-
-
-def test_prepend_missing_key(client: MetaClient) -> None:
-    assert client.prepend("pre_miss", b"v") is False
-
-
-def test_prepend_vivify(client: MetaClient) -> None:
-    assert client.prepend("pre_vivify", b"data", vivify_ttl=60) is True
-    r = client.get("pre_vivify")
-    assert r is not None
-    assert r.value == b"data"
-
-
-# ------------------------------------------------------------------ #
-# cas                                                                #
-# ------------------------------------------------------------------ #
-
-
-def test_cas_success(client: MetaClient) -> None:
-    client.set("cas_key", "initial")
-    r = client.get("cas_key", with_cas=True)
-    assert r is not None
-    assert r.cas_token is not None
-    assert client.cas("cas_key", "updated", r.cas_token) is True
-    r2 = client.get("cas_key")
-    assert r2 is not None
-    assert r2.value == "updated"
-
-
-def test_cas_conflict(client: MetaClient) -> None:
-    client.set("cas_conf", "v")
-    r = client.get("cas_conf", with_cas=True)
-    assert r is not None
-    assert r.cas_token is not None
-    client.set("cas_conf", "modified")
-    assert client.cas("cas_conf", "new", r.cas_token) is False
-    r2 = client.get("cas_conf")
-    assert r2 is not None
-    assert r2.value == "modified"
-
-
-def test_cas_missing_key(client: MetaClient) -> None:
-    assert client.cas("cas_no_key", "v", 12345) is False
-
-
-# ------------------------------------------------------------------ #
-# delete                                                             #
-# ------------------------------------------------------------------ #
-
-
-def test_delete_existing(client: MetaClient) -> None:
-    client.set("del_key", "v")
-    assert client.delete("del_key") is True
-    assert client.get("del_key") is None
-
-
-def test_delete_missing(client: MetaClient) -> None:
-    assert client.delete("del_miss") is False
-
-
-def test_delete_with_cas(client: MetaClient) -> None:
-    client.set("del_cas", "v")
-    r = client.get("del_cas", with_cas=True)
-    assert r is not None
-    assert r.cas_token is not None
-    assert client.delete("del_cas", cas_token=r.cas_token) is True
-
-
-def test_delete_with_wrong_cas(client: MetaClient) -> None:
-    client.set("del_cas_bad", "v")
-    assert client.delete("del_cas_bad", cas_token=99999999) is False
-
-
-# ------------------------------------------------------------------ #
-# invalidate                                                         #
-# ------------------------------------------------------------------ #
-
-
-def test_invalidate(client: MetaClient) -> None:
-    client.set("inv_key", "v")
-    assert client.invalidate("inv_key") is True
-
-
-def test_invalidate_missing(client: MetaClient) -> None:
-    assert client.invalidate("inv_miss") is False
-
-
-def test_invalidate_stale_flag(client: MetaClient) -> None:
-    client.set("inv_stale", "v")
-    client.invalidate("inv_stale", stale_ttl=10)
-    # After invalidation, get should see is_stale=True
-    r = client.get("inv_stale")
-    assert r is not None
-    assert r.is_stale is True
-
-
-# ------------------------------------------------------------------ #
-# incr / decr                                                        #
-# ------------------------------------------------------------------ #
-
-
-def test_incr(client: MetaClient) -> None:
-    client.set("ctr", 10)
-    assert client.incr("ctr") == 11
-
-
-def test_incr_with_delta(client: MetaClient) -> None:
-    client.set("ctr2", 5)
-    assert client.incr("ctr2", 3) == 8
-
-
-def test_incr_missing(client: MetaClient) -> None:
-    with pytest.raises(MemcacheError):
-        client.incr("incr_miss")
-
-
-def test_incr_with_initial(client: MetaClient) -> None:
-    # On miss with J flag, memcached creates item with initial value (delta not applied)
-    assert client.incr("incr_init", initial=100, initial_ttl=60) == 100
-
-
-def test_incr_with_initial_existing(client: MetaClient) -> None:
-    client.set("incr_init_ex", 5)
-    # initial is ignored when key exists
-    assert client.incr("incr_init_ex", initial=100, initial_ttl=60) == 6
-
-
-def test_decr(client: MetaClient) -> None:
-    client.set("dctr", 10)
-    assert client.decr("dctr") == 9
-
-
-def test_decr_with_delta(client: MetaClient) -> None:
-    client.set("dctr2", 10)
-    assert client.decr("dctr2", 3) == 7
-
-
-def test_decr_floor_zero(client: MetaClient) -> None:
-    client.set("dctr3", 1)
-    assert client.decr("dctr3", 5) == 0
-
-
-def test_decr_missing(client: MetaClient) -> None:
-    with pytest.raises(MemcacheError):
-        client.decr("decr_miss")
-
-
-def test_decr_with_initial(client: MetaClient) -> None:
-    result = client.decr("decr_init", initial=50, initial_ttl=60)
-    # On miss with J flag, memcached creates item with initial value (delta not applied)
-    assert result == 50
-
-
-# ------------------------------------------------------------------ #
-# flush_all                                                          #
-# ------------------------------------------------------------------ #
-
-
-def test_flush_all(client: MetaClient) -> None:
-    client.set("flush_k", "v")
-    client.flush_all()
-    assert client.get("flush_k") is None
-
-
-def test_flush_all_with_delay(client: MetaClient) -> None:
-    client.set("flush_d", "v")
-    client.flush_all(delay=0)
-    assert client.get("flush_d") is None
-
-
-# ------------------------------------------------------------------ #
-# execute_meta_command (low-level pass-through)                      #
-# ------------------------------------------------------------------ #
-
-
-def test_execute_meta_command(client: MetaClient) -> None:
-    cmd = MetaCommand(cm=b"ms", key=b"raw_key", datalen=3, flags=[b"T60"], value=b"raw")
-    result = client.execute_meta_command(cmd)
-    assert result.rc == b"HD"
-
-    cmd2 = MetaCommand(cm=b"mg", key=b"raw_key", flags=[b"v"])
-    result2 = client.execute_meta_command(cmd2)
-    assert result2.rc == b"VA"
-    assert result2.value == b"raw"
-
-
-# ------------------------------------------------------------------ #
-# Non-legacy keys: base64 encoding on the wire (b flag)              #
-# ------------------------------------------------------------------ #
-
-
-def test_encode_key() -> None:
-    # Legacy-safe keys are sent verbatim; keys with whitespace/control/binary
-    # bytes are base64-encoded; oversized keys are rejected before sending.
-    assert encode_key(b"plain_key") == (b"plain_key", False)
-    assert encode_key(b"a b") == (base64.b64encode(b"a b"), True)
-    # The 250-byte limit applies to the wire token, so a legacy key may be up
-    # to 250 bytes while a binary key is capped by its (larger) base64 form.
-    with pytest.raises(MemcacheError):
-        encode_key(b"x" * 251)
-    assert encode_key(b"\x00" * 186)[1] is True  # base64 -> 248 bytes, ok
-    with pytest.raises(MemcacheError):
-        encode_key(b"\x00" * 187)  # base64 -> 252 bytes, too long
-
-
-def test_meta_command_encodes_non_legacy_key_on_wire() -> None:
-    cmd = MetaCommand(cm=b"mg", key=b"crlf\r\ninjection", flags=[b"v"])
-    assert cmd.key == b"crlf\r\ninjection"  # raw key kept as-is
-    header = cmd.dump_header()
-    assert base64.b64encode(b"crlf\r\ninjection") in header
-    assert b" b " in header  # base64 flag appended
-    assert b"\r\n" not in header[:-2]  # raw CRLF did not corrupt the frame
-
-
-def test_set_get_non_legacy_key(client: MetaClient) -> None:
-    # End-to-end: the server accepts our base64 + `b` wire format and routing.
-    client.set(b"crlf\r\ninjection", "payload")
-    r = client.get(b"crlf\r\ninjection")
-    assert r is not None
-    assert r.value == "payload"
+def client():
+    with MetaClient(("localhost", 11211)) as value:
+        value.flush_all()
+        yield value
+
+
+def test_explicit_get_states_and_values(client):
+    assert client.get("missing").status is GetStatus.MISS
+    with pytest.raises(ResultValueError):
+        client.get("missing").value
+
+    client.set("none", None)
+    none = client.get("none")
+    assert none.status is GetStatus.HIT
+    assert none.value is None
+    assert bool(none)
+
+    client.set("empty", b"")
+    assert client.get("empty").value == b""
+    assert client.get("missing").value_or("fallback") == "fallback"
+
+
+def test_metadata_inspect_and_conditional_read(client):
+    stored = client.set("article", "body", ttl=60, return_cas=True)
+    assert stored.status is MutationStatus.STORED
+    assert stored.cas is not None
+
+    result = client.get("article", meta=Meta.CAS | Meta.TTL | Meta.SIZE)
+    assert result.item.cas == stored.cas
+    assert result.item.ttl is not None and result.item.ttl > 0
+    assert result.item.size == 4
+
+    unchanged = client.get("article", unless_cas=stored.cas)
+    assert unchanged.status is GetStatus.UNCHANGED
+    assert unchanged.item.cas == stored.cas
+    with pytest.raises(ResultValueError):
+        unchanged.value
+
+    changed = client.get("article", unless_cas=stored.cas + 1)
+    assert changed.status is GetStatus.HIT
+    assert changed.value == "body"
+    assert changed.item.cas == stored.cas
+
+    metadata = client.inspect("article")
+    assert metadata.status is GetStatus.HIT
+    assert metadata.item.size == 4
+    with pytest.raises(ResultValueError):
+        metadata.value
+
+
+def test_conditions_versions_and_conveniences(client):
+    assert client.set("condition", "first", condition=ABSENT)
+    assert client.add("condition", "second").status is MutationStatus.ALREADY_EXISTS
+    assert client.replace("absent", "x").status is MutationStatus.NOT_FOUND
+
+    old = client.get("condition", meta=Meta.CAS)
+    assert (
+        client.cas("condition", "second", old.item.cas).status is MutationStatus.STORED
+    )
+    assert (
+        client.cas("condition", "third", old.item.cas).status
+        is MutationStatus.CAS_MISMATCH
+    )
+
+    versioned = client.set("versioned", "v", version=42, return_cas=True)
+    assert versioned.cas == 42
+    assert client.get("versioned", meta=Meta.CAS).item.cas == 42
+
+
+def test_batch_is_ordered_pipeline_and_keeps_duplicates(client):
+    client.set("a", "A")
+    results = client.batch(
+        [
+            Get("a", meta=Meta.CAS),
+            Get(b"missing"),
+            Set("b", b"B"),
+            Delete("absent"),
+            Get("a"),
+            Increment("counter", initial=10, initial_ttl=60),
+        ]
+    )
+    assert len(results) == 6
+    assert results[0].key == "a" and results[0].value == "A"
+    assert results[1].key == b"missing" and results[1].status is GetStatus.MISS
+    assert results[2].status is MutationStatus.STORED
+    assert results[3].status is MutationStatus.NOT_FOUND
+    assert results[4].value == "A"
+    assert isinstance(results[5], ArithmeticResult)
+    assert results[5].value == 10
+
+    many = client.get_many(["a", b"missing", "a"])
+    assert [item.key for item in many] == ["a", b"missing", "a"]
+    assert [item.status for item in many] == [
+        GetStatus.HIT,
+        GetStatus.MISS,
+        GetStatus.HIT,
+    ]
+
+
+def test_lease_miss_pending_and_fulfill(client):
+    winner = client.get_with_lease("report", lease_ttl=30)
+    assert (winner.value_state, winner.lease_state) == (
+        ValueState.MISSING,
+        LeaseState.GRANTED,
+    )
+    assert winner.status is GetStatus.MISS
+
+    observer = client.get("report")
+    assert observer.status is GetStatus.PENDING
+    assert observer.lease_state is LeaseState.BUSY
+
+    loser = client.get_with_lease("report", lease_ttl=30)
+    assert loser.value_state is ValueState.MISSING
+    assert loser.lease_state is LeaseState.BUSY
+
+    assert winner.fulfill({"ready": True}, ttl=60).status is MutationStatus.STORED
+    assert client.get("report").value == {"ready": True}
+
+
+def test_lease_early_recache_stale_and_all_fulfill_outcomes(client):
+    client.set("early", "value", ttl=30)
+    first = client.get_with_lease("early", lease_ttl=20, refresh_before=60)
+    second = client.get_with_lease("early", lease_ttl=20, refresh_before=60)
+    assert first.value == second.value == "value"
+    assert first.value_state is ValueState.FRESH
+    assert first.lease_state is LeaseState.GRANTED
+    assert second.lease_state is LeaseState.BUSY
+
+    client.set("stale", "old", ttl=60)
+    client.invalidate("stale", stale_for=60)
+    stale = client.get_with_lease("stale", lease_ttl=20)
+    assert stale.value == "old"
+    assert stale.value_state is ValueState.STALE
+    assert stale.lease_state is LeaseState.GRANTED
+
+    client.set("stale", "new")
+    assert stale.fulfill("rebuilt").status is MutationStatus.CAS_MISMATCH
+
+    expired = client.get_with_lease("gone", lease_ttl=20)
+    client.delete("gone")
+    assert expired.fulfill("late").status is MutationStatus.NOT_FOUND
+
+
+def test_byte_concatenation_arithmetic_touch_and_delete(client):
+    client.set("bytes", b"middle")
+    assert client.append_bytes("bytes", b" end")
+    assert client.prepend_bytes("bytes", b"start ")
+    assert client.get("bytes").value == b"start middle end"
+    with pytest.raises(TypeError):
+        client.append_bytes("bytes", "not bytes")
+
+    assert client.increment("n", initial=5, initial_ttl=60).value == 5
+    assert client.increment("n", 3).value == 8
+    assert client.decrement("n", 20).value == 0
+    assert client.touch("n", 60).status is MutationStatus.STORED
+    assert client.touch("no", 60).status is MutationStatus.NOT_FOUND
+
+    current = client.get("n", meta=Meta.CAS)
+    assert (
+        client.delete("n", condition=IfCas(current.item.cas)).status
+        is MutationStatus.STORED
+    )
+    assert client.delete("n").status is MutationStatus.NOT_FOUND
+
+
+def test_binary_key_and_raw_escape_hatch(client):
+    key = b"binary key\x00"
+    client.set(key, "value")
+    assert client.get(key).key == key
+    assert client.get(key).value == "value"
+
+    raw = client.raw.execute(command="mg", key=key, flags=[b"v"])
+    assert raw.rc == b"VA"
+    assert raw.value == b"value"
+
+    raw_batch = client.raw.batch(
+        [MetaCommand(b"mg", key, flags=[b"v"]), MetaCommand(b"mg", b"none")]
+    )
+    assert [item.rc for item in raw_batch] == [b"VA", b"EN"]
+
+
+def test_programming_errors_are_raised_before_batch(client):
+    with pytest.raises(ValueError):
+        client.batch([Get("a", refresh_before=10)])
+    with pytest.raises(ValueError):
+        client.batch([Increment("n", initial=1)])
+    with pytest.raises(ValueError):
+        client.batch([Delete("a", stale_for=10)])
+    with pytest.raises(TypeError):
+        client.set("a", "v", condition=object())


### PR DESCRIPTION
Refactors the experimental meta client around a batch-first async core with matching synchronous APIs. Adds explicit result states, conditional operations, leases, and safe ambiguous-write handling while preserving legacy APIs.